### PR TITLE
Implement configurable ghost block chain limit

### DIFF
--- a/example/spectrum/spectrum.go
+++ b/example/spectrum/spectrum.go
@@ -46,6 +46,7 @@ func main() {
 
 	debug.SetGCPercent(-1)
 	debug.SetMemoryLimit(4 * 1024 * 1024 * 1024) // 4GB
+	fmt.Println("process ID:", os.Getpid())
 
 	opts := util.DefaultOpts()
 	opts.ClientDecode = player.ClientDecode
@@ -76,8 +77,9 @@ func main() {
 	oconfig.Global.Combat.MaximumAttackAngle = 90
 	oconfig.Global.Combat.EnableClientEntityTracking = true
 
-	oconfig.Global.Network.GlobalMovementCutoffThreshold = 6
+	oconfig.Global.Network.GlobalMovementCutoffThreshold = -1
 	oconfig.Global.Network.MaxEntityRewind = 6
+	oconfig.Global.Network.MaxGhostBlockChain = 7
 	oconfig.Global.Network.MaxKnockbackDelay = -1
 	oconfig.Global.Network.MaxBlockUpdateDelay = -1
 
@@ -162,7 +164,10 @@ func main() {
 				f.Close()
 			})
 			proc.Player().SetRecoverFunc(func(p *player.Player, err any) {
-				panic(err)
+				fmt.Println("ERROR:", err)
+				debug.PrintStack()
+				fmt.Println("Please remember this is an example, and you should set this recovery function to something that can log errors, like Sentry.")
+				os.Exit(1)
 			})
 			proc.Player().AddPerm(player.PermissionDebug)
 			proc.Player().AddPerm(player.PermissionAlerts)

--- a/game/error.go
+++ b/game/error.go
@@ -4,7 +4,9 @@ const (
 	ErrorNotReady              = "Error: Client did not initialize correctly."
 	ErrorNetworkTimeout        = "Error: Network timed out."
 	ErrorChunkCacheUnsupported = "Error: Chunk cache is not supported."
-	ErrorInvalidInventorySlot  = "Error: Invalid inventory slot selected."
+
+	ErrorInvalidInventorySlot = "Error: Invalid inventory slot selected."
+	ErrorInvalidBlockFace     = "Error: Invalid block face selected."
 
 	ErrorInternalDecodeChunk                       = "Unable to decode chunk: %v"
 	ErrorInternalDuplicateACK                      = "Error: Duplicated ACKs."

--- a/go.mod
+++ b/go.mod
@@ -56,6 +56,8 @@ require (
 
 //replace github.com/sandertv/gophertunnel => ../tedac-gophertunnel
 
+replace github.com/sandertv/go-raknet => ../go-raknet
+
 replace github.com/sandertv/gophertunnel => ../gophertunnel
 
 replace github.com/df-mc/dragonfly => ../dragonfly

--- a/go.sum
+++ b/go.sum
@@ -133,8 +133,6 @@ github.com/rs/cors v1.11.0/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/samber/lo v1.49.1 h1:4BIFyVfuQSEpluc7Fua+j1NolZHiEHEpaSEKdsH0tew=
 github.com/samber/lo v1.49.1/go.mod h1:dO6KHFzUKXgP8LDhU0oI8d2hekjXnGOu0DB8Jecxd6o=
-github.com/sandertv/go-raknet v1.14.3-0.20250305181847-6af3e95113d6 h1:ZfK7NCzIDE+dzp5x6NIO4JDLsjsOxi762CNR1Obds2Q=
-github.com/sandertv/go-raknet v1.14.3-0.20250305181847-6af3e95113d6/go.mod h1:/yysjwfCXm2+2OY8mBazLzcxJ3irnylKCyG3FLgUPVU=
 github.com/scylladb/go-set v1.0.2 h1:SkvlMCKhP0wyyct6j+0IHJkBkSZL+TDzZ4E7f7BCcRE=
 github.com/scylladb/go-set v1.0.2/go.mod h1:DkpGd78rljTxKAnTDPFqXSGxvETQnJyuSOQwsHycqfs=
 github.com/segmentio/fasthash v1.0.3 h1:EI9+KE1EwvMLBWwjpRDc+fEM+prwxDYbslddQGtrmhM=

--- a/player/component/acknowledgement/block.go
+++ b/player/component/acknowledgement/block.go
@@ -1,48 +1,72 @@
 package acknowledgement
 
 import (
+	"github.com/df-mc/dragonfly/server/block"
 	df_cube "github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/oomph-ac/oomph/player"
 )
 
-// UpdateBlock is an acknowledgment that is ran when a single block is updated in the world of the player.
-// TODO: Improve this acknowledgment to be more efficient (store multiple block placements). Since oomph is able to
-// control when packets are flushed, we should in theory be able to store all block updates into one packet, which would
-// let us run only one world transaction on the Dragonfly world.
-type UpdateBlock struct {
+type UpdateBlockBatch struct {
 	mPlayer *player.Player
-	b       world.Block
-	pos     df_cube.Pos
+	updates map[df_cube.Pos]uint32
 
 	expiresIn int64
 	valid     bool
 }
 
-func NewUpdateBlockACK(p *player.Player, pos df_cube.Pos, b world.Block, expiresIn int64) *UpdateBlock {
-	return &UpdateBlock{mPlayer: p, pos: pos, b: b, valid: true, expiresIn: expiresIn}
+func NewUpdateBlockBatchACK(p *player.Player) *UpdateBlockBatch {
+	return &UpdateBlockBatch{mPlayer: p, updates: make(map[df_cube.Pos]uint32), valid: true}
 }
 
-func (ack *UpdateBlock) Run() {
+func (ack *UpdateBlockBatch) Blocks() map[df_cube.Pos]uint32 {
+	return ack.updates
+}
+
+func (ack *UpdateBlockBatch) SetBlock(pos df_cube.Pos, b uint32) {
+	ack.updates[pos] = b
+}
+
+func (ack *UpdateBlockBatch) RemoveBlock(pos df_cube.Pos) {
+	delete(ack.updates, pos)
+}
+
+func (ack *UpdateBlockBatch) SetExpiry(expiresIn int64) {
+	ack.expiresIn = expiresIn
+}
+
+func (ack *UpdateBlockBatch) HasUpdates() bool {
+	return len(ack.updates) > 0
+}
+
+func (ack *UpdateBlockBatch) Run() {
 	if !ack.valid {
 		return
 	}
-	ack.mPlayer.World().SetBlock(ack.pos, ack.b, nil)
 	ack.valid = false
+	for pos, bRuntimeID := range ack.updates {
+		b, ok := world.BlockByRuntimeID(bRuntimeID)
+		if !ok {
+			ack.mPlayer.Log().Warn("unable to find block with runtime ID", "blockRuntimeID", bRuntimeID)
+			b = block.Air{}
+		}
+		ack.mPlayer.World().SetBlock(pos, b, nil)
+		ack.mPlayer.WorldUpdater().RemovePendingUpdate(pos, bRuntimeID)
+	}
+	ack.updates = nil
 }
 
-func (ack *UpdateBlock) Tick() {
+func (ack *UpdateBlockBatch) Tick() {
 	if !ack.valid {
 		return
 	}
 	ack.expiresIn--
 	if ack.expiresIn <= 0 {
-		ack.mPlayer.Dbg.Notify(player.DebugModeLatency, true, "updateBlock ack for %T at %v lag-compensation expired", ack.b, ack.pos)
 		ack.Run()
 	}
 }
 
-func (ack *UpdateBlock) Invalidate() {
+func (ack *UpdateBlockBatch) Invalidate() {
 	ack.valid = false
-	ack.mPlayer.Dbg.Notify(player.DebugModeChunks, true, "updateBlock ack for %T at %v is invalidated", ack.b, ack.pos)
+	ack.mPlayer.Dbg.Notify(player.DebugModeChunks, true, "updateBlockBatch ack is invalidated")
 }

--- a/player/component/acks.go
+++ b/player/component/acks.go
@@ -182,6 +182,7 @@ func (ackC *ACKComponent) Tick(client bool) {
 // to be handled later.
 func (ackC *ACKComponent) Flush() {
 	//assert.IsTrue(ackC.currentBatch.acks != nil, "no buffer for current timestamp to flush %d", ackC.currentBatch.timestamp)
+	ackC.mPlayer.WorldUpdater().Flush()
 	if ackC.currentBatch == nil {
 		ackC.mPlayer.Disconnect(game.ErrorInternalACKIsNull)
 		return
@@ -204,7 +205,7 @@ func (ackC *ACKComponent) Flush() {
 func (ackC *ACKComponent) Invalidate() {
 	for _, batch := range ackC.pending {
 		for _, ack := range batch.acks {
-			if blockACK, ok := ack.(*acknowledgement.UpdateBlock); ok {
+			if blockACK, ok := ack.(*acknowledgement.UpdateBlockBatch); ok {
 				blockACK.Invalidate()
 			}
 		}

--- a/player/component/inventory.go
+++ b/player/component/inventory.go
@@ -44,6 +44,8 @@ type InventoryComponent struct {
 	currentRequest *invReq
 
 	heldSlot int32
+
+	pendingInventorySync bool
 }
 
 func NewInventoryComponent(p *player.Player) *InventoryComponent {
@@ -123,7 +125,7 @@ func (c *InventoryComponent) Sync(windowID int32) bool {
 		WindowID: uint32(windowID),
 		Content:  contents,
 	})
-
+	c.pendingInventorySync = false
 	return true
 }
 
@@ -171,6 +173,10 @@ func (c *InventoryComponent) SyncSlot(windowID int32, slot int) bool {
 }
 
 func (c *InventoryComponent) ForceSync() {
+	if c.pendingInventorySync {
+		return
+	}
+	c.pendingInventorySync = true
 	// Sending a mismatch transaction to the server forces the server to re-send all inventories.
 	if conn := c.mPlayer.ServerConn(); conn != nil {
 		_ = conn.WritePacket(&packet.InventoryTransaction{

--- a/player/component/movement.go
+++ b/player/component/movement.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/ethaniccc/float32-cube/cube"
 	"github.com/go-gl/mathgl/mgl32"
-	"github.com/oomph-ac/oomph/entity"
 	"github.com/oomph-ac/oomph/game"
 	"github.com/oomph-ac/oomph/player"
 	"github.com/oomph-ac/oomph/player/component/acknowledgement"
@@ -955,7 +954,7 @@ func (mc *AuthoritativeMovementComponent) Sync() {
 
 	if !mc.mPlayer.PendingCorrectionACK {
 		// Make sure all of the player's actor data is up-to-date with Oomph's prediction.
-		actorData := mc.mPlayer.LastSetActorData
+		/* actorData := mc.mPlayer.LastSetActorData
 		actorData.Tick = mc.mPlayer.SimulationFrame
 		if f, ok := actorData.EntityMetadata[entity.DataKeyFlags]; ok {
 			flags := f.(int64)
@@ -976,7 +975,7 @@ func (mc *AuthoritativeMovementComponent) Sync() {
 			}
 			actorData.EntityMetadata[entity.DataKeyFlags] = flags
 		}
-		mc.mPlayer.SendPacketToClient(actorData)
+		mc.mPlayer.SendPacketToClient(actorData) */
 		// Send the actual movement correction to the client.
 		mc.mPlayer.SendPacketToClient(&packet.CorrectPlayerMovePrediction{
 			PredictionType: packet.PredictionTypePlayer,

--- a/player/component/world.go
+++ b/player/component/world.go
@@ -111,6 +111,11 @@ func (c *WorldUpdaterComponent) AttemptItemInteractionWithBlock(pk *packet.Inven
 		return false
 	}
 
+	// Ignore if the block face the client sends is not valid.
+	if dat.BlockFace < 0 || dat.BlockFace > 5 {
+		return false
+	}
+
 	clickedBlockPos := utils.BlockToCubePos(dat.BlockPosition)
 	dfClickedBlockPos := df_cube.Pos(clickedBlockPos)
 	replacingBlock := c.mPlayer.World().Block(dfClickedBlockPos)

--- a/player/detection/bad_packet_g.go
+++ b/player/detection/bad_packet_g.go
@@ -1,0 +1,70 @@
+package detection
+
+import (
+	"github.com/oomph-ac/oomph/player"
+	"github.com/oomph-ac/oomph/utils"
+	"github.com/sandertv/gophertunnel/minecraft/protocol"
+	"github.com/sandertv/gophertunnel/minecraft/protocol/packet"
+)
+
+type BadPacketG struct {
+	mPlayer  *player.Player
+	metadata *player.DetectionMetadata
+}
+
+func New_BadPacketG(p *player.Player) *BadPacketG {
+	return &BadPacketG{
+		mPlayer: p,
+		metadata: &player.DetectionMetadata{
+			FailBuffer:    1,
+			MaxBuffer:     1,
+			MaxViolations: 1,
+		},
+	}
+}
+
+func (*BadPacketG) Type() string {
+	return TypeBadPacket
+}
+
+func (*BadPacketG) SubType() string {
+	return "G"
+}
+
+func (*BadPacketG) Description() string {
+	return "Checks if the player is sending an invalid block-face value."
+}
+
+func (*BadPacketG) Punishable() bool {
+	return true
+}
+
+func (d *BadPacketG) Metadata() *player.DetectionMetadata {
+	return d.metadata
+}
+
+func (d *BadPacketG) Detect(pk packet.Packet) {
+	switch pk := pk.(type) {
+	case *packet.InventoryTransaction:
+		trDat, ok := pk.TransactionData.(*protocol.UseItemTransactionData)
+		if !ok {
+			return
+		}
+		if !utils.IsBlockFaceValid(trDat.BlockFace) {
+			d.mPlayer.FailDetection(d, nil)
+		}
+	case *packet.PlayerAuthInput:
+		if pk.InputData.Load(packet.InputFlagPerformItemInteraction) {
+			if !utils.IsBlockFaceValid(pk.ItemInteractionData.BlockFace) {
+				d.mPlayer.FailDetection(d, nil)
+			}
+		}
+		if pk.InputData.Load(packet.InputFlagPerformBlockActions) {
+			for _, action := range pk.BlockActions {
+				if !utils.IsBlockFaceValid(action.Face) {
+					d.mPlayer.FailDetection(d, nil)
+				}
+			}
+		}
+	}
+}

--- a/player/detection/register.go
+++ b/player/detection/register.go
@@ -16,6 +16,7 @@ func Register(p *player.Player) {
 	p.RegisterDetection(New_BadPacketD(p))
 	p.RegisterDetection(New_BadPacketE(p))
 	p.RegisterDetection(New_BadPacketF(p))
+	p.RegisterDetection(New_BadPacketG(p))
 
 	// edition faker detections
 	p.RegisterDetection(New_EditionFakerA(p))

--- a/player/player.go
+++ b/player/player.go
@@ -543,6 +543,7 @@ func (p *Player) Tick() bool {
 
 	p.movement.Tick(p.ServerTick - prevTick)
 	p.entTracker.Tick(p.ServerTick)
+	p.worldUpdater.Tick()
 	p.acks.Tick(false)
 	if !p.acks.Responsive() {
 		p.Disconnect(game.ErrorNetworkTimeout)

--- a/player/world.go
+++ b/player/world.go
@@ -129,14 +129,19 @@ func (p *Player) PlaceBlock(clickedBlockPos, replaceBlockPos df_cube.Pos, face d
 
 	// Check if any entity is in the way of the block being placed.
 	entityIntersecting := false
-	var entTracker EntityTrackerComponent = p.EntityTracker()
 	if p.Opts().Combat.EnableClientEntityTracking {
-		entTracker = p.ClientEntityTracker()
-	}
-	for _, e := range entTracker.All() {
-		if cube.AnyIntersections(boxes, e.Box(e.Position)) {
-			entityIntersecting = true
-			break
+		for _, e := range p.ClientEntityTracker().All() {
+			if cube.AnyIntersections(boxes, e.Box(e.Position)) {
+				entityIntersecting = true
+				break
+			}
+		}
+	} else {
+		for _, e := range p.EntityTracker().All() {
+			if rew, ok := e.Rewind(p.ClientTick); ok && cube.AnyIntersections(boxes, e.Box(rew.Position)) {
+				entityIntersecting = true
+				break
+			}
 		}
 	}
 

--- a/utils/face.go
+++ b/utils/face.go
@@ -16,3 +16,7 @@ func GetFaceFromRotation(yaw float32) cube.Face {
 		return cube.FaceWest
 	}
 }
+
+func IsBlockFaceValid(face int32) bool {
+	return face >= 0 && face <= 5
+}


### PR DESCRIPTION
This is intended to help mitigate the effects of cheaters using ghost blocks to seem as if they are flying by implementing a configurable limit as to how many ghost blocks can be placed against each other.