### PR TITLE
fix(legacy-events): do not apply punishments when legacy events are enabled

### DIFF
--- a/player/detection.go
+++ b/player/detection.go
@@ -99,7 +99,7 @@ func (p *Player) FailDetection(d Detection, keyvals ...any) {
 		)
 	}
 
-	if oconfig.Global.UseLegacyEvents && d.Punishable() && m.Violations >= m.MaxViolations {
+	if !oconfig.Global.UseLegacyEvents && d.Punishable() && m.Violations >= m.MaxViolations {
 		ctx = event.C(p)
 		message := DefaultDetectionDisconnectMessage
 		p.EventHandler().HandlePunishment(ctx, d, &message)


### PR DESCRIPTION
Activating legacy-events to use the oomph-pm configuration does not work the plugin system as it detects the default oomph configuration.