### PR TITLE
fix arrow & xp_orb preventing block placement

### DIFF
--- a/player/world.go
+++ b/player/world.go
@@ -15,7 +15,6 @@ import (
 	oworld "github.com/oomph-ac/oomph/world"
 	"github.com/sandertv/gophertunnel/minecraft/protocol"
 	"github.com/sandertv/gophertunnel/minecraft/protocol/packet"
-	"slices"
 )
 
 // WorldUpdaterComponent is a component that handles block and chunk updates to the world of the member player.
@@ -131,13 +130,11 @@ func (p *Player) PlaceBlock(clickedBlockPos, replaceBlockPos df_cube.Pos, face d
 		return
 	}
 
-	exceptedEntityTypes := []string{"minecraft:xp_orb", "minecraft:arrow"}
-
 	// Check if any entity is in the way of the block being placed.
 	entityIntersecting := false
 	if p.Opts().Combat.EnableClientEntityTracking {
 		for _, e := range p.ClientEntityTracker().All() {
-			if slices.Contains(exceptedEntityTypes, e.Type) {
+			if utils.IsEntityPassBlockPlacement(e.Type) {
 				continue
 			}
 			if cube.AnyIntersections(boxes, e.Box(e.Position)) {
@@ -147,7 +144,7 @@ func (p *Player) PlaceBlock(clickedBlockPos, replaceBlockPos df_cube.Pos, face d
 		}
 	} else {
 		for _, e := range p.EntityTracker().All() {
-			if slices.Contains(exceptedEntityTypes, e.Type) {
+			if utils.IsEntityPassBlockPlacement(e.Type) {
 				continue
 			}
 			if rew, ok := e.Rewind(p.ClientTick); ok && cube.AnyIntersections(boxes, e.Box(rew.Position)) {

--- a/utils/entity.go
+++ b/utils/entity.go
@@ -9,3 +9,11 @@ func GetValueFromStringMap[T any](list map[string]any, key string, value *T) boo
 	}
 	return false
 }
+
+func IsEntityPassBlockPlacement(entityType string) bool {
+	switch entityType {
+	case "minecraft:arrow", "minecraft:xp_orb":
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
Vanilla allows placing blocks when the placement position intersects with an arrow or an XP orb