### PR TITLE
fix: transfer movement state leak on server handoff

### DIFF
--- a/player/acks.go
+++ b/player/acks.go
@@ -31,6 +31,8 @@ type AcknowledgmentComponent interface {
 	Refresh()
 	// Invalidate labels all pending UpdateBlock acknowledgments as invalid - this is primarily for transfers.
 	Invalidate()
+	// ResetTransferState clears ACK state that must not survive a fast transfer.
+	ResetTransferState()
 }
 
 // Acknowledgment is an interface for client acknowledgments to be ran once the member player

--- a/player/component/acks.go
+++ b/player/component/acks.go
@@ -212,6 +212,15 @@ func (ackC *ACKComponent) Invalidate() {
 	}
 }
 
+// ResetTransferState clears all ACK batches so stale acknowledgments from the old backend
+// cannot mutate the new session once the client responds after a fast transfer.
+func (ackC *ACKComponent) ResetTransferState() {
+	ackC.clientTicked = false
+	ackC.ticksSinceLastResponse = 0
+	ackC.pending = ackC.pending[:0]
+	ackC.Refresh()
+}
+
 // Refresh resets the current timestamp of the acknowledgment component.
 func (ackC *ACKComponent) Refresh() {
 	ackC.currentBatch = &ackBatch{timestamp: 0, acks: make([]player.Acknowledgment, 0)}

--- a/player/component/movement.go
+++ b/player/component/movement.go
@@ -1006,6 +1006,9 @@ func (mc *AuthoritativeMovementComponent) Sync() {
 	if !mc.mPlayer.PendingCorrectionACK {
 		// Make sure all of the player's actor data is up-to-date with Oomph's prediction.
 		actorData := mc.mPlayer.LastSetActorData
+		if actorData == nil {
+			return
+		}
 		actorData.Tick = mc.mPlayer.SimulationFrame
 		if f, ok := actorData.EntityMetadata[entity.DataKeyFlags]; ok {
 			flags := f.(int64)
@@ -1038,4 +1041,84 @@ func (mc *AuthoritativeMovementComponent) Sync() {
 		})
 		mc.mPlayer.PendingCorrectionACK = true
 	}
+}
+
+// ResetTransferState clears movement/session state that should never survive a fast transfer.
+func (mc *AuthoritativeMovementComponent) ResetTransferState(pos mgl32.Vec3) {
+	mc.pos = pos
+	mc.lastPos = pos
+	mc.vel = mgl32.Vec3{}
+	mc.lastVel = mgl32.Vec3{}
+	mc.mov = mgl32.Vec3{}
+	mc.lastMov = mgl32.Vec3{}
+
+	mc.nonAuthoritative.pos = pos
+	mc.nonAuthoritative.lastPos = pos
+	mc.nonAuthoritative.vel = mgl32.Vec3{}
+	mc.nonAuthoritative.lastVel = mgl32.Vec3{}
+	mc.nonAuthoritative.mov = mgl32.Vec3{}
+	mc.nonAuthoritative.lastMov = mgl32.Vec3{}
+	mc.nonAuthoritative.toggledFly = false
+	mc.nonAuthoritative.horizontalCollision = false
+	mc.nonAuthoritative.verticalCollision = false
+
+	mc.slideOffset = mgl32.Vec2{}
+	mc.impulse = mgl32.Vec2{}
+	mc.supportingBlockPos = nil
+
+	mc.gravity = game.NormalGravity
+	mc.jumpHeight = game.DefaultJumpHeight
+	mc.fallDistance = 0
+
+	mc.movementSpeed = mc.defaultMovementSpeed
+	mc.airSpeed = 0.02
+	mc.serverUpdatedSpeed = false
+
+	mc.knockback = mgl32.Vec3{}
+	mc.ticksSinceKb = 1
+
+	mc.pendingTeleportPos = pos
+	mc.pendingTeleports = 0
+	mc.teleportPos = pos
+	mc.ticksSinceTeleport = 1
+	mc.teleportCompletionTicks = 0
+	mc.teleportIsSmoothed = false
+
+	mc.sprinting = false
+	mc.pressingSprint = false
+	mc.serverSprint = false
+	mc.serverSprintApplied = false
+
+	mc.sneaking = false
+	mc.pressingSneak = false
+
+	mc.jumping = false
+	mc.pressingJump = false
+	mc.jumpDelay = 0
+
+	mc.collideX = false
+	mc.collideY = false
+	mc.collideZ = false
+	mc.onGround = false
+
+	mc.penetratedLastFrame = false
+	mc.stuckInCollider = false
+
+	mc.immobile = false
+	mc.noClip = false
+
+	mc.gliding = false
+	mc.glideBoostTicks = 0
+	mc.hasGravity = true
+
+	mc.flying = false
+	mc.mayFly = false
+	mc.trustFlyStatus = false
+	mc.justDisabledFlight = false
+
+	mc.allowedInputs = 65535
+	mc.hasFirstInput = false
+
+	mc.pendingCorrections = 0
+	mc.inCorrectionCooldown = false
 }

--- a/player/movement.go
+++ b/player/movement.go
@@ -258,6 +258,8 @@ type MovementComponent interface {
 
 	// Sync sends a correction to the client to re-sync the client's movement with the server's.
 	Sync()
+	// ResetTransferState clears movement state that must not survive a fast transfer.
+	ResetTransferState(pos mgl32.Vec3)
 }
 
 // NonAuthoritativeMovementInfo represents movement information that the player has sent to the server but has not validated/verified.

--- a/player/network.go
+++ b/player/network.go
@@ -43,14 +43,14 @@ func (p *Player) SetServerConn(conn ServerConn) {
 	}
 
 	if p.serverConn == nil {
-		p.GameDat = conn.GameData()
-		for _, item := range p.GameDat.Items {
+		for _, item := range conn.GameData().Items {
 			if i, ok := world.ItemByName(item.Name, 0); ok {
 				p.items[item.RuntimeID] = i
 			}
 		}
 	}
 
+	p.GameDat = conn.GameData()
 	p.serverConn = conn
 	p.RuntimeId = conn.GameData().EntityRuntimeID
 	p.UniqueId = conn.GameData().EntityUniqueID
@@ -59,8 +59,9 @@ func (p *Player) SetServerConn(conn ServerConn) {
 		p.GameMode = conn.GameData().WorldGameMode
 	}
 
-	p.movement.SetPos(p.GameDat.PlayerPosition)
-	p.movement.SetVel(mgl32.Vec3{})
+	p.PendingCorrectionACK = false
+	p.acks.ResetTransferState()
+	p.movement.ResetTransferState(p.GameDat.PlayerPosition)
 }
 
 // ChunkRadius returns the chunk radius as requested by the client at the other end of the conn.


### PR DESCRIPTION
refresh GameData and clear stale teleport/correction ACK state during transfer resets. Which likely fixes transfer only movement desync.

If this doesn't fix it, then my next guess is this is a spectral issue.

Issue: https://discord.com/channels/1155700266105053257/1488301175785783347
(Only spotted after player transfers: hub -> factions -> hub)