### PR TITLE
perf(combat): tighten server-auth combat hot paths

### DIFF
--- a/entity/rewind.go
+++ b/entity/rewind.go
@@ -16,36 +16,53 @@ type HistoricalPosition struct {
 }
 
 // Rewind looks back in the position history of the entity, and returns the position at the given tick.
+// History is ordered by tick, so once the delta stops improving we can stop scanning.
 func (e *Entity) Rewind(tick int64) (HistoricalPosition, bool) {
-	if e.PositionHistory.Size() == 0 {
+	if e.PositionHistory == nil || e.PositionHistory.Size() == 0 {
 		e.debug("no position history available - attempting to re-create entity buffer", "runtime_id", e.RuntimeId)
 		if e.historySize <= 0 {
 			panic(oerror.New("entity.Rewind: unable to re-create entity rewind buffer: recorded history size is zero"))
 		}
 		e.PositionHistory = utils.NewCircularQueue(e.historySize, func() (hp HistoricalPosition) { return })
-		return HistoricalPosition{}, false // We can't return anything here because we just re-created the buffer.
+		return HistoricalPosition{}, false
 	}
 
+	buf, head, size := e.PositionHistory.Items()
+	bufLen := len(buf)
+
 	var (
-		result HistoricalPosition
-		delta  int64 = 1_000_000_000_000
+		result    HistoricalPosition
+		found     bool
+		bestDelta int64
 	)
 
-	for hp := range e.PositionHistory.Iter() {
+	for i := 0; i < size; i++ {
+		hp := buf[(head+i)%bufLen]
+
+		// uninitialized slots.
+		if hp.Tick == 0 {
+			continue
+		}
+
 		if hp.Tick == tick {
 			return hp, true
 		}
 
 		currentDelta := hp.Tick - tick
 		if currentDelta < 0 {
-			currentDelta *= -1
+			currentDelta = -currentDelta
 		}
 
-		if currentDelta <= delta {
+		if !found || currentDelta < bestDelta {
+			bestDelta = currentDelta
 			result = hp
-			delta = currentDelta
+			found = true
+			continue
 		}
+
+		// Delta started increasing, so we are past the closest match.
+		break
 	}
 
-	return result, true
+	return result, found
 }

--- a/player/component/combat.go
+++ b/player/component/combat.go
@@ -62,11 +62,14 @@ type AuthoritativeCombatComponent struct {
 }
 
 func NewAuthoritativeCombatComponent(p *player.Player, useClientTracker bool) *AuthoritativeCombatComponent {
+	// Pre-size result slices to avoid reallocations during a typical hit.
+	const sliceCap = (CombatLerpPositionSteps + 1) * 2
+
 	return &AuthoritativeCombatComponent{
 		mPlayer:                p,
-		raycastResults:         make([]float32, 0, CombatLerpPositionSteps*2),
-		rawResults:             make([]float32, 0, CombatLerpPositionSteps*2),
-		angleResults:           make([]float32, 0, CombatLerpPositionSteps*2),
+		raycastResults:         make([]float32, 0, sliceCap),
+		rawResults:             make([]float32, 0, sliceCap),
+		angleResults:           make([]float32, 0, sliceCap),
 		hooks:                  []player.CombatHook{},
 		uniqueAttackedEntities: make(map[uint64]*entity.Entity),
 
@@ -182,11 +185,13 @@ func (c *AuthoritativeCombatComponent) Calculate() bool {
 		return true
 	}
 
-	t := time.Now()
-	defer func() {
-		delta := float64(time.Since(t).Nanoseconds()) / 1_000_000.0
-		c.mPlayer.Dbg.Notify(player.DebugModeCombat, true, "took %.4fms to process", delta)
-	}()
+	if c.mPlayer.Dbg.Enabled(player.DebugModeCombat) {
+		t := time.Now()
+		defer func() {
+			delta := float64(time.Since(t).Nanoseconds()) / 1_000_000.0
+			c.mPlayer.Dbg.Notify(player.DebugModeCombat, true, "took %.4fms to process", delta)
+		}()
+	}
 
 	var (
 		closestHitResult trace.BBoxResult
@@ -213,19 +218,21 @@ func (c *AuthoritativeCombatComponent) Calculate() bool {
 	}
 
 	movement := c.mPlayer.Movement()
-	if movement.PendingCorrections() > 0 && c.useClientTracker {
-		c.mPlayer.Dbg.Notify(player.DebugModeCombat, true, "movement component indicates pending corrections (%d) - hit invalidated", movement.PendingCorrections())
-		return false
+	if c.useClientTracker {
+		if pending := movement.PendingCorrections(); pending > 0 {
+			c.mPlayer.Dbg.Notify(player.DebugModeCombat, true, "movement component indicates pending corrections (%d) - hit invalidated", pending)
+			return false
+		}
 	}
 
-	hasNonSmoothTeleport := movement.HasTeleport() && !movement.TeleportSmoothed()
-	if hasNonSmoothTeleport {
-		c.startAttackPos = movement.TeleportPos()
-		c.endAttackPos = movement.TeleportPos()
+	if movement.HasTeleport() && !movement.TeleportSmoothed() {
+		teleportPos := movement.TeleportPos()
+		c.startAttackPos = teleportPos
+		c.endAttackPos = teleportPos
 	}
 
-	c.startRotation = c.mPlayer.Movement().LastRotation()
-	c.endRotation = c.mPlayer.Movement().Rotation()
+	c.startRotation = movement.LastRotation()
+	c.endRotation = movement.Rotation()
 
 	var (
 		altEntityStartPos mgl32.Vec3
@@ -239,8 +246,14 @@ func (c *AuthoritativeCombatComponent) Calculate() bool {
 	}
 
 	hitValid := false
-	stepAmt := 1.0 / float32(CombatLerpPositionSteps)
-	for partialTicks := float32(0.0); partialTicks <= 1; partialTicks += stepAmt {
+	const totalSteps = CombatLerpPositionSteps + 1
+	invSteps := float32(1.0) / float32(CombatLerpPositionSteps)
+	for step := 0; step < totalSteps; step++ {
+		partialTicks := float32(step) * invSteps
+		if step == CombatLerpPositionSteps {
+			// Force the final step to the exact end frame.
+			partialTicks = 1.0
+		}
 		lerpedResult := c.lerp(partialTicks)
 		entityBB := c.entityBB.Translate(lerpedResult.entityPos).Grow(0.1)
 		dV := game.DirectionVector(lerpedResult.rotation.Z(), lerpedResult.rotation.X())
@@ -411,29 +424,33 @@ func (c *AuthoritativeCombatComponent) checkForMispredictedEntity() bool {
 	}
 
 	var (
-		minDist        float32 = 1_000_000
 		targetedEntity *entity.Entity
 		rewindData     entity.HistoricalPosition
 		eid            uint64
 	)
 
+	const radiusSq = CombatSurvivalEntitySearchRadius * CombatSurvivalEntitySearchRadius
+	var minDistSq float32 = 1_000_000
+
 	// We subtract the rewind tick by 1 here, because the client has already ticked in this instance (which increases)
 	// the client tick by 1, so we have to rewind to the previous tick.
 	rewTick := c.mPlayer.ClientTick - 1
+	attackPos := c.endAttackPos
 	for rid, e := range c.entityTracker().All() {
 		rewind, ok := e.Rewind(rewTick)
 		if !ok {
 			continue
 		}
 
-		dist := rewind.Position.Sub(c.endAttackPos).Len()
-		if dist <= CombatSurvivalEntitySearchRadius {
-			if dist < minDist {
-				minDist = dist
-				rewindData = rewind
-				targetedEntity = e
-				eid = rid
-			}
+		dx := rewind.Position[0] - attackPos[0]
+		dy := rewind.Position[1] - attackPos[1]
+		dz := rewind.Position[2] - attackPos[2]
+		distSq := dx*dx + dy*dy + dz*dz
+		if distSq <= radiusSq && distSq < minDistSq {
+			minDistSq = distSq
+			rewindData = rewind
+			targetedEntity = e
+			eid = rid
 		}
 	}
 

--- a/utils/circular_queue.go
+++ b/utils/circular_queue.go
@@ -60,6 +60,13 @@ func (q *CircularQueue[T]) Size() int {
 	return q.size
 }
 
+// Items returns the raw buffer along with the head index and current size.
+// Elements are laid out circularly. element i (0 = oldest) is at
+// buf[(head+i) % len(buf)].
+func (q *CircularQueue[T]) Items() (buf []T, head, size int) {
+	return q.items, q.head, q.size
+}
+
 // Pop removes and returns the oldest element. The boolean ok is false if the
 // queue is empty.
 func (q *CircularQueue[T]) Pop() (item T, ok bool) {


### PR DESCRIPTION
Fixes a latent rewind bug and reduces per tick work in authoritative combat.

## Performance Changes
`entity.Rewind` no longer scans the entire ring buffer or returns a zero-valued position with `ok=true` when no valid history exists.
Iteration now skips uninitialized slots and exits early once the closest tick is passed.
Also avoids the allocating `iter.Seq` path by iterating the underlying buffer directly.
`CircularQueue.Items()` exposes the buffer, head, and size so hot paths can iterate without allocations.

## Hot path improvements
Gate `time.Now` / `time.Since` debug timing behind `Dbg.Enabled`.
Switch lerp loop to integer stepping (final step forced to `1.0`) to avoid float drift.
Cache `Movement()` lookup per call.
Pre-size result slices to worst case to avoid reallocations.
Use squared distance in misprediction checks to skip per-entity `sqrt`.