### PR TITLE
perf(combat): tighten server-auth combat hot paths

### DIFF
--- a/entity/rewind.go
+++ b/entity/rewind.go
@@ -16,36 +16,53 @@ type HistoricalPosition struct {
 }
 
 // Rewind looks back in the position history of the entity, and returns the position at the given tick.
+// History is ordered by tick, so once the delta stops improving we can stop scanning.
 func (e *Entity) Rewind(tick int64) (HistoricalPosition, bool) {
-	if e.PositionHistory.Size() == 0 {
+	if e.PositionHistory == nil || e.PositionHistory.Size() == 0 {
 		e.debug("no position history available - attempting to re-create entity buffer", "runtime_id", e.RuntimeId)
 		if e.historySize <= 0 {
 			panic(oerror.New("entity.Rewind: unable to re-create entity rewind buffer: recorded history size is zero"))
 		}
 		e.PositionHistory = utils.NewCircularQueue(e.historySize, func() (hp HistoricalPosition) { return })
-		return HistoricalPosition{}, false // We can't return anything here because we just re-created the buffer.
+		return HistoricalPosition{}, false
 	}
 
+	buf, head, size := e.PositionHistory.Items()
+	bufLen := len(buf)
+
 	var (
-		result HistoricalPosition
-		delta  int64 = 1_000_000_000_000
+		result    HistoricalPosition
+		found     bool
+		bestDelta int64
 	)
 
-	for hp := range e.PositionHistory.Iter() {
+	for i := 0; i < size; i++ {
+		hp := buf[(head+i)%bufLen]
+
+		// uninitialized slots.
+		if hp.Tick == 0 {
+			continue
+		}
+
 		if hp.Tick == tick {
 			return hp, true
 		}
 
 		currentDelta := hp.Tick - tick
 		if currentDelta < 0 {
-			currentDelta *= -1
+			currentDelta = -currentDelta
 		}
 
-		if currentDelta <= delta {
+		if !found || currentDelta < bestDelta {
+			bestDelta = currentDelta
 			result = hp
-			delta = currentDelta
+			found = true
+			continue
 		}
+
+		// Delta started increasing, so we are past the closest match.
+		break
 	}
 
-	return result, true
+	return result, found
 }

--- a/entity/rewind.go
+++ b/entity/rewind.go
@@ -27,7 +27,7 @@ func (e *Entity) Rewind(tick int64) (HistoricalPosition, bool) {
 		return HistoricalPosition{}, false // We can't return anything here because we just re-created the buffer.
 	}
 
-	buf, head, size := e.PositionHistory.Items()
+	buf, head, size := e.PositionHistory.UnsafeItems()
 	bufLen := len(buf)
 
 	var (

--- a/entity/rewind.go
+++ b/entity/rewind.go
@@ -24,7 +24,7 @@ func (e *Entity) Rewind(tick int64) (HistoricalPosition, bool) {
 			panic(oerror.New("entity.Rewind: unable to re-create entity rewind buffer: recorded history size is zero"))
 		}
 		e.PositionHistory = utils.NewCircularQueue(e.historySize, func() (hp HistoricalPosition) { return })
-		return HistoricalPosition{}, false
+		return HistoricalPosition{}, false // We can't return anything here because we just re-created the buffer.
 	}
 
 	buf, head, size := e.PositionHistory.Items()

--- a/entity/rewind.go
+++ b/entity/rewind.go
@@ -31,7 +31,7 @@ func (e *Entity) Rewind(tick int64) (HistoricalPosition, bool) {
 
 	var (
 		best      HistoricalPosition
-		bestDelta int64 = 1_000_000_000_000
+		bestDelta int64
 		found     bool
 	)
 
@@ -52,7 +52,6 @@ func (e *Entity) Rewind(tick int64) (HistoricalPosition, bool) {
 			currentDelta *= -1
 		}
 
-		// Keep old tie behavior: later equal-distance entries override earlier ones.
 		if !found || currentDelta <= bestDelta {
 			best = hp
 			bestDelta = currentDelta

--- a/entity/rewind.go
+++ b/entity/rewind.go
@@ -28,18 +28,17 @@ func (e *Entity) Rewind(tick int64) (HistoricalPosition, bool) {
 	}
 
 	buf, head, size := e.PositionHistory.UnsafeItems()
-	bufLen := len(buf)
 
 	var (
-		result    HistoricalPosition
+		best      HistoricalPosition
+		bestDelta int64 = 1_000_000_000_000
 		found     bool
-		bestDelta int64
 	)
 
 	for i := 0; i < size; i++ {
-		hp := buf[(head+i)%bufLen]
+		hp := buf[(head+i)%len(buf)]
 
-		// uninitialized slots.
+		// Skip uninitialized slots.
 		if hp.Tick == 0 {
 			continue
 		}
@@ -50,19 +49,20 @@ func (e *Entity) Rewind(tick int64) (HistoricalPosition, bool) {
 
 		currentDelta := hp.Tick - tick
 		if currentDelta < 0 {
-			currentDelta = -currentDelta
+			currentDelta *= -1
 		}
 
-		if !found || currentDelta < bestDelta {
+		// Keep old tie behavior: later equal-distance entries override earlier ones.
+		if !found || currentDelta <= bestDelta {
+			best = hp
 			bestDelta = currentDelta
-			result = hp
 			found = true
 			continue
 		}
 
-		// Delta started increasing, so we are past the closest match.
+		// Deltas increased after already finding a candidate -> no better result ahead.
 		break
 	}
 
-	return result, found
+	return best, found
 }

--- a/player/component/combat.go
+++ b/player/component/combat.go
@@ -246,14 +246,12 @@ func (c *AuthoritativeCombatComponent) Calculate() bool {
 	}
 
 	hitValid := false
-	const totalSteps = CombatLerpPositionSteps + 1
-	invSteps := float32(1.0) / float32(CombatLerpPositionSteps)
-	for step := 0; step < totalSteps; step++ {
-		partialTicks := float32(step) * invSteps
-		if step == CombatLerpPositionSteps {
-			// Force the final step to the exact end frame.
-			partialTicks = 1.0
-		}
+
+	stepAmt := 1.0 / float32(CombatLerpPositionSteps)
+
+	for step := 0; step <= CombatLerpPositionSteps; step++ {
+		partialTicks := float32(step) * stepAmt
+
 		lerpedResult := c.lerp(partialTicks)
 		entityBB := c.entityBB.Translate(lerpedResult.entityPos).Grow(0.1)
 		dV := game.DirectionVector(lerpedResult.rotation.Z(), lerpedResult.rotation.X())
@@ -306,6 +304,7 @@ func (c *AuthoritativeCombatComponent) Calculate() bool {
 				altRaycastDist := lerpedResult.attackPos.Sub(hitResult.Position()).Len()
 				hitValid = hitValid || altRaycastDist <= CombatSurvivalReach
 				c.raycastResults = append(c.raycastResults, altRaycastDist)
+
 				if altRaycastDist < closestRaycastDist {
 					closestRaycastDist = altRaycastDist
 					closestHitResult = hitResult
@@ -313,9 +312,11 @@ func (c *AuthoritativeCombatComponent) Calculate() bool {
 				}
 				raycastHit = true
 			}
+
 			closestPoint := game.ClosestPointToBBox(lerpedResult.attackPos, altEntityBB)
 			rawDist := lerpedResult.attackPos.Sub(closestPoint).Len()
 			c.rawResults = append(c.rawResults, rawDist)
+
 			if rawDist < closestRawDist {
 				closestRawDist = rawDist
 				closestRawPos = closestPoint
@@ -325,6 +326,7 @@ func (c *AuthoritativeCombatComponent) Calculate() bool {
 		closestPoint := game.ClosestPointToBBox(lerpedResult.attackPos, entityBB)
 		rawDist := lerpedResult.attackPos.Sub(closestPoint).Len()
 		c.rawResults = append(c.rawResults, rawDist)
+
 		if rawDist < closestRawDist {
 			closestRawDist = rawDist
 			closestRawPos = closestPoint

--- a/player/component/combat.go
+++ b/player/component/combat.go
@@ -62,11 +62,14 @@ type AuthoritativeCombatComponent struct {
 }
 
 func NewAuthoritativeCombatComponent(p *player.Player, useClientTracker bool) *AuthoritativeCombatComponent {
+	// Pre-size result slices to avoid reallocations during a typical hit.
+	const sliceCap = (CombatLerpPositionSteps + 1) * 2
+
 	return &AuthoritativeCombatComponent{
 		mPlayer:                p,
-		raycastResults:         make([]float32, 0, CombatLerpPositionSteps*2),
-		rawResults:             make([]float32, 0, CombatLerpPositionSteps*2),
-		angleResults:           make([]float32, 0, CombatLerpPositionSteps*2),
+		raycastResults:         make([]float32, 0, sliceCap),
+		rawResults:             make([]float32, 0, sliceCap),
+		angleResults:           make([]float32, 0, sliceCap),
 		hooks:                  []player.CombatHook{},
 		uniqueAttackedEntities: make(map[uint64]*entity.Entity),
 
@@ -182,11 +185,13 @@ func (c *AuthoritativeCombatComponent) Calculate() bool {
 		return true
 	}
 
-	t := time.Now()
-	defer func() {
-		delta := float64(time.Since(t).Nanoseconds()) / 1_000_000.0
-		c.mPlayer.Dbg.Notify(player.DebugModeCombat, true, "took %.4fms to process", delta)
-	}()
+	if c.mPlayer.Dbg.Enabled(player.DebugModeCombat) {
+		t := time.Now()
+		defer func() {
+			delta := float64(time.Since(t).Nanoseconds()) / 1_000_000.0
+			c.mPlayer.Dbg.Notify(player.DebugModeCombat, true, "took %.4fms to process", delta)
+		}()
+	}
 
 	var (
 		closestHitResult trace.BBoxResult
@@ -213,19 +218,21 @@ func (c *AuthoritativeCombatComponent) Calculate() bool {
 	}
 
 	movement := c.mPlayer.Movement()
-	if movement.PendingCorrections() > 0 && c.useClientTracker {
-		c.mPlayer.Dbg.Notify(player.DebugModeCombat, true, "movement component indicates pending corrections (%d) - hit invalidated", movement.PendingCorrections())
-		return false
+	if c.useClientTracker {
+		if pending := movement.PendingCorrections(); pending > 0 {
+			c.mPlayer.Dbg.Notify(player.DebugModeCombat, true, "movement component indicates pending corrections (%d) - hit invalidated", pending)
+			return false
+		}
 	}
 
-	hasNonSmoothTeleport := movement.HasTeleport() && !movement.TeleportSmoothed()
-	if hasNonSmoothTeleport {
-		c.startAttackPos = movement.TeleportPos()
-		c.endAttackPos = movement.TeleportPos()
+	if movement.HasTeleport() && !movement.TeleportSmoothed() {
+		teleportPos := movement.TeleportPos()
+		c.startAttackPos = teleportPos
+		c.endAttackPos = teleportPos
 	}
 
-	c.startRotation = c.mPlayer.Movement().LastRotation()
-	c.endRotation = c.mPlayer.Movement().Rotation()
+	c.startRotation = movement.LastRotation()
+	c.endRotation = movement.Rotation()
 
 	var (
 		altEntityStartPos mgl32.Vec3
@@ -239,8 +246,14 @@ func (c *AuthoritativeCombatComponent) Calculate() bool {
 	}
 
 	hitValid := false
-	stepAmt := 1.0 / float32(CombatLerpPositionSteps)
-	for partialTicks := float32(0.0); partialTicks <= 1; partialTicks += stepAmt {
+	const totalSteps = CombatLerpPositionSteps + 1
+	invSteps := float32(1.0) / float32(CombatLerpPositionSteps)
+	for step := 0; step < totalSteps; step++ {
+		partialTicks := float32(step) * invSteps
+		if step == CombatLerpPositionSteps {
+			// Force the final step to the exact end frame.
+			partialTicks = 1.0
+		}
 		lerpedResult := c.lerp(partialTicks)
 		entityBB := c.entityBB.Translate(lerpedResult.entityPos).Grow(0.1)
 		dV := game.DirectionVector(lerpedResult.rotation.Z(), lerpedResult.rotation.X())
@@ -411,29 +424,33 @@ func (c *AuthoritativeCombatComponent) checkForMispredictedEntity() bool {
 	}
 
 	var (
-		minDist        float32 = 1_000_000
 		targetedEntity *entity.Entity
 		rewindData     entity.HistoricalPosition
 		eid            uint64
 	)
 
+	const radiusSq = CombatSurvivalEntitySearchRadius * CombatSurvivalEntitySearchRadius
+	var minDistSq float32 = 1_000_000
+
 	// We subtract the rewind tick by 1 here, because the client has already ticked in this instance (which increases)
 	// the client tick by 1, so we have to rewind to the previous tick.
 	rewTick := c.mPlayer.ClientTick - 1
+	attackPos := c.endAttackPos
 	for rid, e := range c.entityTracker().All() {
 		rewind, ok := e.Rewind(rewTick)
 		if !ok {
 			continue
 		}
 
-		dist := rewind.Position.Sub(c.endAttackPos).Len()
-		if dist <= CombatSurvivalEntitySearchRadius {
-			if dist < minDist {
-				minDist = dist
-				rewindData = rewind
-				targetedEntity = e
-				eid = rid
-			}
+		dx := rewind.Position[0] - attackPos[0]
+		dy := rewind.Position[1] - attackPos[1]
+		dz := rewind.Position[2] - attackPos[2]
+		distSq := dx*dx + dy*dy + dz*dz
+		if distSq <= radiusSq && distSq < minDistSq {
+			minDistSq = distSq
+			rewindData = rewind
+			targetedEntity = e
+			eid = rid
 		}
 	}
 

--- a/utils/circular_queue.go
+++ b/utils/circular_queue.go
@@ -61,7 +61,7 @@ func (q *CircularQueue[T]) Size() int {
 }
 
 // Items returns the raw buffer along with the head index and current size.
-// Elements are laid out circularly. element i (0 = oldest) is at
+// Elements are laid out circularly. Element i (0 = oldest) is at
 // buf[(head+i) % len(buf)].
 func (q *CircularQueue[T]) Items() (buf []T, head, size int) {
 	return q.items, q.head, q.size

--- a/utils/circular_queue.go
+++ b/utils/circular_queue.go
@@ -60,6 +60,13 @@ func (q *CircularQueue[T]) Size() int {
 	return q.size
 }
 
+// Items returns the raw buffer along with the head index and current size.
+// Elements are laid out circularly. element i (0 = oldest) is at
+// buf[(head+i) % len(buf)].
+func (q *CircularQueue[T]) Items() (buf []T, head, size int) {
+	return q.items, q.head, q.size
+}
+
 // Pop removes and returns the oldest element. The boolean ok is false if the
 // queue is empty.
 func (q *CircularQueue[T]) Pop() (item T, ok bool) {

--- a/utils/circular_queue.go
+++ b/utils/circular_queue.go
@@ -60,10 +60,9 @@ func (q *CircularQueue[T]) Size() int {
 	return q.size
 }
 
-// Items returns the raw buffer along with the head index and current size.
-// Elements are laid out circularly. Element i (0 = oldest) is at
-// buf[(head+i) % len(buf)].
-func (q *CircularQueue[T]) Items() (buf []T, head, size int) {
+// UnsafeItems returns the internal buffer, head, and size without cloning.
+// Mutating the returned slice will affect the queue's internal state.
+func (q *CircularQueue[T]) UnsafeItems() (buf []T, head, size int) {
 	return q.items, q.head, q.size
 }
 


### PR DESCRIPTION
Fixes a latent rewind bug and reduces per tick work in authoritative combat.

## Performance Changes
`entity.Rewind` no longer scans the entire ring buffer or returns a zero-valued position with `ok=true` when no valid history exists.
Iteration now skips uninitialized slots and exits early once the closest tick is passed.
Also avoids the allocating `iter.Seq` path by iterating the underlying buffer directly.
`CircularQueue.Items()` exposes the buffer, head, and size so hot paths can iterate without allocations.

## Hot path improvements
Gate `time.Now` / `time.Since` debug timing behind `Dbg.Enabled`.
Switch lerp loop to integer stepping (final step forced to `1.0`) to avoid float drift.
Cache `Movement()` lookup per call.
Pre-size result slices to worst case to avoid reallocations.
Use squared distance in misprediction checks to skip per-entity `sqrt`.