### PR TITLE
refactor: player logs

### DIFF
--- a/player/component/inventory.go
+++ b/player/component/inventory.go
@@ -154,7 +154,7 @@ func (c *InventoryComponent) RemoveWindow(windowId byte) {
 		return
 	}
 	c.altOpenWindow = nil
-	c.mPlayer.Log().Debug("removed container inventory", "windowID", windowId)
+	//c.mPlayer.Log().Debug("removed container inventory", "windowID", windowId)
 }
 
 func (c *InventoryComponent) SyncSlot(windowID int32, slot int) bool {
@@ -210,7 +210,7 @@ func (c *InventoryComponent) HandleInventoryContent(pk *packet.InventoryContent)
 }
 
 func (c *InventoryComponent) HandleSingleRequest(request protocol.ItemStackRequest) {
-	c.mPlayer.Log().Debug("received item stack request", "requestID", request.RequestID)
+	//c.mPlayer.Log().Debug("received item stack request", "requestID", request.RequestID)
 	tx := newInvRequest(request.RequestID)
 
 	for _, action := range request.Actions {

--- a/player/component/inventory_transaction.go
+++ b/player/component/inventory_transaction.go
@@ -131,7 +131,7 @@ func (a *transferAction) execute() {
 	a.oldSrcItem, a.oldDstItem = srcItem, dstItem
 
 	if srcItem.Empty() {
-		mPlayer.Log().Debug("unexpected empty source item")
+		//mPlayer.Log().Debug("unexpected empty source item")
 		return
 	}
 	if dstItem.Empty() {
@@ -150,13 +150,13 @@ func (a *transferAction) revert() {
 
 	srcInv, foundSrcInv := mPlayer.Inventory().WindowFromContainerID(int32(a.srcInv))
 	if !foundSrcInv {
-		mPlayer.Log().Debug("source inventory with given container ID not found", "srcInv", a.srcInv)
+		//mPlayer.Log().Debug("source inventory with given container ID not found", "srcInv", a.srcInv)
 		return
 	}
 
 	dstInv, foundDstInv := mPlayer.Inventory().WindowFromContainerID(int32(a.dstInv))
 	if !foundDstInv {
-		mPlayer.Log().Debug("destination inventory with given container ID not found", "dstInv", a.dstInv)
+		//mPlayer.Log().Debug("destination inventory with given container ID not found", "dstInv", a.dstInv)
 		return
 	}
 
@@ -210,13 +210,13 @@ func (a *swapAction) execute() {
 
 	srcInv, foundSrcInv := mPlayer.Inventory().WindowFromContainerID(a.srcInv)
 	if !foundSrcInv {
-		mPlayer.Log().Debug("source inventory with given container ID not found", "srcInv", a.srcInv)
+		//mPlayer.Log().Debug("source inventory with given container ID not found", "srcInv", a.srcInv)
 		return
 	}
 
 	dstInv, foundDstInv := mPlayer.Inventory().WindowFromContainerID(a.dstInv)
 	if !foundDstInv {
-		mPlayer.Log().Debug("detination inventory with given container ID not found", "dstInv", a.dstInv)
+		//mPlayer.Log().Debug("detination inventory with given container ID not found", "dstInv", a.dstInv)
 		return
 	}
 
@@ -236,13 +236,13 @@ func (a *swapAction) revert() {
 
 	srcInv, foundSrcInv := mPlayer.Inventory().WindowFromContainerID(a.srcInv)
 	if !foundSrcInv {
-		mPlayer.Log().Debug("source inventory with given container ID not found", "srcInv", a.srcInv)
+		//mPlayer.Log().Debug("source inventory with given container ID not found", "srcInv", a.srcInv)
 		return
 	}
 
 	dstInv, foundDstInv := mPlayer.Inventory().WindowFromContainerID(a.dstInv)
 	if !foundDstInv {
-		mPlayer.Log().Debug("destination inventory with given container ID not found", "dstInv", a.dstInv)
+		//mPlayer.Log().Debug("destination inventory with given container ID not found", "dstInv", a.dstInv)
 		return
 	}
 

--- a/player/debug.go
+++ b/player/debug.go
@@ -65,6 +65,9 @@ type Debugger struct {
 	Modes       map[int]bool
 	LoggingType byte
 
+	movSimBuf       []string
+	bufferingMovSim bool
+
 	target *Player
 }
 
@@ -106,10 +109,41 @@ func (d *Debugger) Notify(mode int, cond bool, msg string, args ...interface{}) 
 		return
 	}
 
+	formatted := fmt.Sprintf(msg, args...)
+	if mode == DebugModeMovementSim && d.bufferingMovSim {
+		d.movSimBuf = append(d.movSimBuf, formatted)
+		return
+	}
+
+	d.writeDebug(mode, formatted)
+}
+
+func (d *Debugger) writeDebug(mode int, msg string) {
 	switch d.LoggingType {
 	case LoggingTypeLogFile:
-		d.target.Log().Debug("[" + DebugModeList[mode] + "]: " + fmt.Sprintf(msg, args...))
+		d.target.Log().Debug("[" + DebugModeList[mode] + "]: " + msg)
 	default:
-		d.target.Message(msg, args...)
+		d.target.Message("[" + DebugModeList[mode] + "]: " + msg)
 	}
+}
+
+// StartMovementSimBuffer begins buffering movement sim debug logs instead of writing them immediately.
+func (d *Debugger) StartMovementSimBuffer() {
+	d.movSimBuf = d.movSimBuf[:0]
+	d.bufferingMovSim = true
+}
+
+// FlushMovementSimBuffer writes all buffered movement sim logs and ends buffering.
+func (d *Debugger) FlushMovementSimBuffer() {
+	for _, entry := range d.movSimBuf {
+		d.writeDebug(DebugModeMovementSim, entry)
+	}
+	d.movSimBuf = d.movSimBuf[:0]
+	d.bufferingMovSim = false
+}
+
+// DiscardMovementSimBuffer drops all buffered movement sim logs and ends buffering.
+func (d *Debugger) DiscardMovementSimBuffer() {
+	d.movSimBuf = d.movSimBuf[:0]
+	d.bufferingMovSim = false
 }

--- a/player/movement.go
+++ b/player/movement.go
@@ -303,6 +303,7 @@ func (p *Player) handleMovement(pk *packet.PlayerAuthInput) {
 		int32(p.movement.Pos().Z()) >> 4,
 	})
 	p.effects.Tick()
+	p.Dbg.StartMovementSimBuffer()
 	p.movement.Update(pk)
 
 	// If the client's prediction of movement deviates from the server, we send a correction so that the client can re-sync.
@@ -360,6 +361,12 @@ func (p *Player) handleMovement(pk *packet.PlayerAuthInput) {
 				)
 			}
 		}
+	}
+
+	if p.movement.PendingCorrections() > 0 {
+		p.Dbg.FlushMovementSimBuffer()
+	} else {
+		p.Dbg.DiscardMovementSimBuffer()
 	}
 
 	// To prevent the server never accepting our position (PMMP), we will always set our position to the final teleport position if a teleport is in progress.


### PR DESCRIPTION
Buffer movement sim logs and flush on corrections or pending corrections. Discard successful frames and centralize debug output handling.

- added movement sim log buffering to Debugger
- store movement sim debug output even when debug logging is disabled
- flush buffered logs to player log when simulation results in correction
- flushed when PendingCorrections() > 0
- discarded buffered logs on successful/no-correction frames
- centralized debug output routing with writeDebug helper
- kept normal frames silent for performance and cleaner logs
- commented out certain legacy player logs (@ethaniccc approved)