### PR TITLE
edition_faker_a: skip detection when titleID is empty

### DIFF
--- a/player/detection/edition_faker_a.go
+++ b/player/detection/edition_faker_a.go
@@ -96,6 +96,11 @@ func (d *EditionFakerA) Detect(pk packet.Packet) {
 	deviceOS := d.mPlayer.ClientDat.DeviceOS
 	titleID := d.mPlayer.IdentityDat.TitleID
 
+	if titleID == "" {
+		// No title ID, newer versions seem to send it a different way. Oh well..
+		return
+	}
+
 	// 1904044383 is the title ID of the preview client in MC:BE. According to @GameParrot, the preview client
 	// can be found on Windows, iOS, and Xbox.
 	if titleID == titleIDPreview {


### PR DESCRIPTION
Newer client versions appear to send the title ID through a different mechanism, so an empty value should not be treated as a mismatch.

https://claude.ai/code/session_01LRUT1h17EkeuzSEhKghFFH

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Small change but it weakens a cheat-detection gate by skipping `EditionFakerA` validation when `TitleID` is absent, which could reduce detection coverage if attackers can omit it.
> 
> **Overview**
> `EditionFakerA` now **early-exits when `IdentityDat.TitleID` is empty**, avoiding false positives for newer clients that don’t populate the field.
> 
> All subsequent OS/title-ID mismatch checks (including preview-client validation) are skipped in this empty-`TitleID` case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 233b60015934ce34ae4c45bbb34a017612ca3a9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->