### PR TITLE
fix: expose combat validator configuration

### DIFF
--- a/oconfig/combat.go
+++ b/oconfig/combat.go
@@ -22,6 +22,31 @@ type CombatOpts struct {
 	// AllowSwitchInputMode is a boolean indicating if the proxy should allow players to switch their input mode, or if it should enforce one input mode to be used unless the player re-joins the server. This can primarily
 	// be used to prevent players from using exploits that switch the input mode to touch only when enabled to obtain a combat advantage. This option is recommended to be set to false.
 	AllowSwitchInputMode bool `json:"allow_switch_input_mode" comment:"Should Oomph allow players to switch their input mode?\nIt is recommended to keep this option disabled as it may allow for tiny combat gains from players switching their input mode to touch."`
+
+	// DisableFullAuthoritative removes server-side gating of attack packets:
+	// attacks always forward, while detections still flag rejected hits.
+	DisableFullAuthoritative bool `json:"disable_full_authoritative" comment:"If true, attacks always forward to the remote server even if Oomph's validator rejects them.\nDetections still flag — they just no longer block hit registration. Default: false."`
+	// DisableBlockOcclusionCheck disables the wall-occlusion check while
+	// retaining reach and angle validation.
+	DisableBlockOcclusionCheck bool `json:"disable_block_occlusion_check" comment:"If true, hits are not invalidated when their ray passes through a solid block.\nUseful when client/server block-state desync (e.g. a recently-broken block) eats legit hits. Default: false."`
+	// RawDistanceFallback accepts in-cone, in-reach hits with no raycast
+	// intersection for non-touch input modes. Touch always uses this fallback.
+	RawDistanceFallback bool `json:"raw_distance_fallback" comment:"If true, accepts the closest-point-on-bbox distance for non-touch input modes when no raycast lands.\nMEANINGFUL WEAKENING of reach detection — accepts any in-cone, in-reach attack. Default: false."`
+
+	// BBoxExpansion grows the targeted entity's bounding box during raycast.
+	// Negative values fall back to 0.1; zero means no growth.
+	BBoxExpansion float64 `json:"bbox_expansion" comment:"Amount the targeted entity's bbox is grown during raycast. Larger = more lenient on edge-of-hitbox hits.\nNegative falls back to 0.1; 0 is honoured as 'exact bbox, no growth'."`
+	// MaximumReach is the maximum allowed distance for a survival hit.
+	// Non-positive values fall back to 2.9.
+	MaximumReach float64 `json:"maximum_reach" comment:"Maximum allowed distance for a valid survival hit. <= 0 falls back to 2.9 (zero reach would land no hits)."`
+	// ReachLeniency is added to MaximumReach for the raycast pass only.
+	ReachLeniency float64 `json:"reach_leniency" comment:"Added to MaximumReach for the raycast pass only. Absorbs ~1 frame of jitter without weakening raw-distance reach. Default: 0."`
+	// LerpSteps is the partial-tick sample count between the previous and
+	// current attack positions. Non-positive values fall back to 10.
+	LerpSteps int `json:"lerp_steps" comment:"Partial-tick sample count between previous and current attack position when validating hits.\nHigher = more accurate, more CPU. <= 0 falls back to 10."`
+	// EntitySearchRadius controls misprediction resolution for client air
+	// swings. Negative values fall back to 6; zero disables the search.
+	EntitySearchRadius float64 `json:"entity_search_radius" comment:"Radius the misprediction-search uses when the client swung in air but may have hit something.\nNegative falls back to 6.0; 0 is honoured as 'do not search' (disables misprediction resolution — anti-cheat hole)."`
 }
 
 func Combat() CombatOpts {

--- a/oconfig/config.go
+++ b/oconfig/config.go
@@ -1,7 +1,7 @@
 package oconfig
 
 const (
-	ConfigVersion          uint64 = 6
+	ConfigVersion          uint64 = 7
 	DefaultShutdownMessage        = "§cServer is restarting."
 )
 
@@ -90,6 +90,15 @@ var (
 			EnableClientEntityTracking: true,
 			AllowNonMobileTouch:        false,
 			AllowSwitchInputMode:       false,
+
+			DisableFullAuthoritative:   false,
+			DisableBlockOcclusionCheck: false,
+			RawDistanceFallback:        false,
+			BBoxExpansion:              0.1,
+			MaximumReach:               2.9,
+			ReachLeniency:              0,
+			LerpSteps:                  10,
+			EntitySearchRadius:         6,
 		},
 
 		Detections: map[string]Detection{

--- a/oconfig/config_test.go
+++ b/oconfig/config_test.go
@@ -13,3 +13,31 @@ func TestDefaultConfigHasCurrentVersion(t *testing.T) {
 		t.Fatal("DefaultConfig.Detections must not be empty")
 	}
 }
+
+func TestDefaultCombatValidatorOptions(t *testing.T) {
+	combat := DefaultConfig.Combat
+	if combat.DisableFullAuthoritative {
+		t.Fatal("DisableFullAuthoritative must default to false")
+	}
+	if combat.DisableBlockOcclusionCheck {
+		t.Fatal("DisableBlockOcclusionCheck must default to false")
+	}
+	if combat.RawDistanceFallback {
+		t.Fatal("RawDistanceFallback must default to false")
+	}
+	if combat.BBoxExpansion != 0.1 {
+		t.Fatalf("BBoxExpansion = %v, want 0.1", combat.BBoxExpansion)
+	}
+	if combat.MaximumReach != 2.9 {
+		t.Fatalf("MaximumReach = %v, want 2.9", combat.MaximumReach)
+	}
+	if combat.ReachLeniency != 0 {
+		t.Fatalf("ReachLeniency = %v, want 0", combat.ReachLeniency)
+	}
+	if combat.LerpSteps != 10 {
+		t.Fatalf("LerpSteps = %v, want 10", combat.LerpSteps)
+	}
+	if combat.EntitySearchRadius != 6 {
+		t.Fatalf("EntitySearchRadius = %v, want 6", combat.EntitySearchRadius)
+	}
+}

--- a/oconfig/json_test.go
+++ b/oconfig/json_test.go
@@ -8,6 +8,32 @@ import (
 	"testing"
 )
 
+func TestParseRawJSONMigratesVersionSixCombatValidatorOptions(t *testing.T) {
+	cfg, err := ParseRawJSON([]byte(`{
+		version: 6
+		combat_opts: {
+			maximum_attack_angle: 72
+			disable_block_occlusion_check: true
+			maximum_reach: 3.25
+		}
+	}`))
+	if !errors.Is(err, ErrConfigUpdated) {
+		t.Fatalf("ParseRawJSON() error = %v, want ErrConfigUpdated", err)
+	}
+	if cfg.Version != ConfigVersion {
+		t.Fatalf("Version = %d, want %d", cfg.Version, ConfigVersion)
+	}
+	if cfg.Combat.MaximumAttackAngle != 72 {
+		t.Fatalf("MaximumAttackAngle = %v, want preserved value 72", cfg.Combat.MaximumAttackAngle)
+	}
+	if !cfg.Combat.DisableBlockOcclusionCheck || cfg.Combat.MaximumReach != 3.25 {
+		t.Fatalf("existing combat validator values were not preserved: %#v", cfg.Combat)
+	}
+	if cfg.Combat.BBoxExpansion != 0.1 || cfg.Combat.LerpSteps != 10 || cfg.Combat.EntitySearchRadius != 6 {
+		t.Fatalf("combat validator defaults not populated: %#v", cfg.Combat)
+	}
+}
+
 func TestParseRawJSONMigratesVersionFiveWithoutLosingValues(t *testing.T) {
 	defaultReach := DefaultConfig.Detections["Reach_A"]
 	raw := []byte(`{
@@ -59,7 +85,7 @@ func TestParseRawJSONMigratesVersionFiveWithoutLosingValues(t *testing.T) {
 
 func TestParseRawJSONRejectsNewerConfigVersion(t *testing.T) {
 	_, err := ParseRawJSON([]byte(`{
-		version: 7
+		version: 8
 		prefix: future-prefix
 	}`))
 	if !errors.Is(err, ErrConfigTooNew) {
@@ -101,7 +127,7 @@ func TestParseRawJSONVersionZeroDoesNotShareDefaultDetections(t *testing.T) {
 func TestParseJSONDoesNotRewriteNewerConfig(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "oomph.hjson")
 	original := []byte(`{
-		version: 7
+		version: 8
 		future_setting: keep-me
 	}`)
 	if err := os.WriteFile(path, original, 0o600); err != nil {
@@ -178,7 +204,7 @@ func TestParseJSONSetsGlobalForCurrentConfig(t *testing.T) {
 func TestParseJSONLeavesCurrentConfigFileUnchanged(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "oomph.hjson")
 	original := []byte(`{
-		version: 6
+		version: 7
 		prefix: current-prefix
 		third_party_setting: keep-me
 		# preserve this comment and formatting
@@ -213,5 +239,23 @@ func TestParseJSONCreatesMissingConfig(t *testing.T) {
 	}
 	if _, err := os.Stat(path); err != nil {
 		t.Fatalf("created config: %v", err)
+	}
+}
+
+func TestCreateJSONWritesReadableCombatDecimals(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "oomph.hjson")
+	if err := CreateJSON(path); err != nil {
+		t.Fatal(err)
+	}
+	written, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(written)
+	if !strings.Contains(text, "bbox_expansion: 0.1\n") {
+		t.Fatalf("generated config does not contain readable bbox expansion:\n%s", text)
+	}
+	if !strings.Contains(text, "maximum_reach: 2.9\n") {
+		t.Fatalf("generated config does not contain readable maximum reach:\n%s", text)
 	}
 }

--- a/player/component/combat.go
+++ b/player/component/combat.go
@@ -16,7 +16,7 @@ import (
 	"github.com/sandertv/gophertunnel/minecraft/protocol/packet"
 )
 
-// Defaults used as fallback when the matching LocalCombatOpts field is unset
+// Defaults used as fallback when the matching CombatOpts field is unset
 // (see per-field docs for the sentinel each one checks).
 const (
 	CombatLerpPositionSteps                  = 10
@@ -64,14 +64,14 @@ type AuthoritativeCombatComponent struct {
 
 	// lerpSteps is captured at construction so result-slice caps stay correct
 	// and Calculate doesn't re-read it each tick. Runtime LerpSteps mutation
-	// therefore takes effect next session (documented on LocalCombatOpts).
+	// therefore takes effect next session (documented on CombatOpts).
 	lerpSteps int
 }
 
 func NewAuthoritativeCombatComponent(p *player.Player, useClientTracker bool) *AuthoritativeCombatComponent {
 	steps := CombatLerpPositionSteps
-	if cfg := p.Opts(); cfg != nil && cfg.LocalCombat.LerpSteps > 0 {
-		steps = cfg.LocalCombat.LerpSteps
+	if cfg := p.Opts(); cfg != nil && cfg.Combat.LerpSteps > 0 {
+		steps = cfg.Combat.LerpSteps
 	}
 	sliceCap := (steps + 1) * 2
 
@@ -260,19 +260,19 @@ func (c *AuthoritativeCombatComponent) Calculate() bool {
 
 	hitValid := false
 
-	local := c.mPlayer.Opts().LocalCombat
+	local := c.mPlayer.Opts().Combat
 	lerpSteps := c.lerpSteps // captured at construction; see field doc
 	// 0 is honoured as "exact bbox" for BBoxExpansion; only negative values
 	// fall back to the default.
-	bboxGrow := local.BBoxExpansion
+	bboxGrow := float32(local.BBoxExpansion)
 	if bboxGrow < 0 {
 		bboxGrow = CombatDefaultBBoxExpansion
 	}
-	maxReach := local.MaximumReach
+	maxReach := float32(local.MaximumReach)
 	if maxReach <= 0 {
 		maxReach = CombatSurvivalReach
 	}
-	raycastReach := maxReach + local.ReachLeniency
+	raycastReach := maxReach + float32(local.ReachLeniency)
 
 	stepAmt := 1.0 / float32(lerpSteps)
 
@@ -477,7 +477,7 @@ func (c *AuthoritativeCombatComponent) checkForMispredictedEntity() bool {
 	)
 
 	// 0 is honoured as "don't search"; only negative falls back to the default.
-	radius := c.mPlayer.Opts().LocalCombat.EntitySearchRadius
+	radius := float32(c.mPlayer.Opts().Combat.EntitySearchRadius)
 	if radius < 0 {
 		radius = CombatSurvivalEntitySearchRadius
 	}

--- a/player/opts.go
+++ b/player/opts.go
@@ -6,65 +6,6 @@ type Opts struct {
 	Combat   oconfig.CombatOpts
 	Movement oconfig.MovementOpts
 	Network  oconfig.NetworkOpts
-
-	// LocalCombat tunes the server-authoritative combat validator: knobs to
-	// trade detection strictness for hit-registration leniency.
-	//
-	// The zero value is unsafe — BBoxExpansion=0 is honoured as "exact bbox"
-	// and EntitySearchRadius=0 disables misprediction resolution (a real
-	// killaura hole). Callers constructing Opts{} directly MUST seed this
-	// from DefaultLocalCombatOpts(); player.New() already does so.
-	LocalCombat LocalCombatOpts
-}
-
-// LocalCombatOpts controls the server-authoritative combat component's
-// hit-validation behaviour. The zero value is unsafe for production — see
-// Opts.LocalCombat. Construct via DefaultLocalCombatOpts() and tweak.
-type LocalCombatOpts struct {
-	// DisableFullAuthoritative removes server-side gating of attack packets:
-	// attacks always forward, detections still flag but no longer block the
-	// hit. Default: false (gating on).
-	DisableFullAuthoritative bool
-	// DisableBlockOcclusionCheck disables the wall-occlusion check (reach/
-	// angle gating still applies). Useful when client/server block-state
-	// desync eats legit hits. Default: false (check on).
-	DisableBlockOcclusionCheck bool
-	// RawDistanceFallback also accepts in-cone, in-reach hits with no raycast
-	// intersection for non-touch input modes (touch always gets this).
-	// Meaningful weakening of reach detection. Default: false.
-	RawDistanceFallback bool
-
-	// BBoxExpansion grows the targeted entity's bbox during raycast.
-	// Negative => fallback to default 0.1; 0 is honoured as "exact bbox".
-	BBoxExpansion float32
-	// MaximumReach is the max allowed distance for a valid survival hit.
-	// <= 0 falls back to 2.9 (zero reach would land no hits).
-	MaximumReach float32
-	// ReachLeniency is added to MaximumReach for the raycast pass only,
-	// absorbing ~1 frame of jitter without weakening raw-distance reach.
-	// Default: 0.
-	ReachLeniency float32
-	// LerpSteps is the partial-tick sample count between previous and current
-	// attack position. <= 0 falls back to 10. Captured once at construction
-	// (sizes pre-allocated slices); runtime changes apply next session.
-	LerpSteps int
-	// EntitySearchRadius is the misprediction-search radius for client
-	// air-swings. Negative => fallback to default 6.0; 0 is honoured as
-	// "do not search" (disables misprediction resolution entirely).
-	EntitySearchRadius float32
-}
-
-// DefaultLocalCombatOpts returns oomph's original strict combat tuning.
-// Use this when constructing Opts{} directly — the zero LocalCombatOpts{}
-// is not numerically equivalent (see Opts.LocalCombat).
-func DefaultLocalCombatOpts() LocalCombatOpts {
-	return LocalCombatOpts{
-		BBoxExpansion:      0.1,
-		MaximumReach:       2.9,
-		ReachLeniency:      0.0,
-		LerpSteps:          10,
-		EntitySearchRadius: 6.0,
-	}
 }
 
 func (p *Player) Opts() *Opts {

--- a/player/player.go
+++ b/player/player.go
@@ -265,7 +265,6 @@ func New(log *slog.Logger, mState MonitoringState, listener *minecraft.Listener)
 	p.opts.Combat = oconfig.Combat()
 	p.opts.Movement = oconfig.Movement()
 	p.opts.Network = oconfig.Network()
-	p.opts.LocalCombat = DefaultLocalCombatOpts()
 
 	p.world = world.New(func(msg string, args ...any) {
 		p.Dbg.Notify(DebugModeChunks, true, msg, args...)


### PR DESCRIPTION
## Summary

- port the combat validator settings missed during the OConfig consolidation
- bump the persisted config schema from 6 to 7 while preserving version-6 values and adding safe defaults
- consume the settings directly from `oconfig.CombatOpts` and remove the duplicate `player.LocalCombatOpts`
- serialize the new decimal settings cleanly instead of exposing float32 precision noise

## Root cause

OConfig PR #2 remained unmerged when OConfig `main` was folded into Oomph. The runtime settings from Oomph PR #128 therefore existed only in `player.LocalCombatOpts` and were not available in persisted configuration.

## Validation

- `go test -race ./...`
- `go vet ./...`
- `git diff --check`
- `codex review --uncommitted` (no findings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how hit validation is configured and sourced at runtime; mis-tuned or migrated `combat_opts` can weaken reach/killaura enforcement or alter which attacks reach the backend.
> 
> **Overview**
> Moves **server-authoritative combat validator** tuning out of duplicate `player.LocalCombatOpts` into **`oconfig.CombatOpts`**, so reach, bbox growth, lerp steps, misprediction search, and flags like `disable_full_authoritative` / `raw_distance_fallback` are editable in `combat_opts` on disk.
> 
> **Config schema v6 → v7** adds safe defaults for the new fields; loading older files keeps existing `combat_opts` values and fills in missing validator knobs. **`AuthoritativeCombatComponent`** now reads `p.Opts().Combat` (with `float64`→`float32` at use sites); **`player.New`** no longer seeds a separate local struct.
> 
> Tests lock default validator values, v6 migration behavior, and that generated config writes readable decimals (e.g. `0.1`, `2.9`) instead of float32 noise.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15f7807959b418c54a92251acbabc9e796f8b9dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable combat validation settings, including reach limits, hitbox expansion, raycast leniency, wall-occlusion checks, distance fallback, interpolation, and entity search radius.
  - Added options to adjust authoritative attack validation behavior.
- **Bug Fixes**
  - Existing configuration files now migrate combat settings automatically while preserving supported values.
  - Generated configuration output presents combat decimal values more clearly.
- **Documentation**
  - Added descriptions for the new combat settings and clarified when certain changes take effect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->