### PR TITLE
fix: match native transfer state cleanup

### DIFF
--- a/integration/proxy/proxy.go
+++ b/integration/proxy/proxy.go
@@ -463,6 +463,9 @@ func (s *session) rewriteServerPacket(pk packet.Packet) bool {
 	case *packet.AddItemActor:
 		rewriteRuntimeID(&pk.EntityRuntimeID)
 		rewriteUniqueID(&pk.EntityUniqueID)
+	case *packet.AddPainting:
+		rewriteRuntimeID(&pk.EntityRuntimeID)
+		rewriteUniqueID(&pk.EntityUniqueID)
 	case *packet.MoveActorAbsolute:
 		rewriteRuntimeID(&pk.EntityRuntimeID)
 	case *packet.MovePlayer:

--- a/integration/proxy/proxy.go
+++ b/integration/proxy/proxy.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"math"
 	"net"
 	"sync"
 	"time"
@@ -169,6 +170,7 @@ type session struct {
 	clientRuntimeID uint64
 	clientUniqueID  int64
 	clientDimension int32
+	state           *backendStateTracker
 }
 
 func newSession(proxy *Proxy, p *player.Player, client clientConn, backend Backend) *session {
@@ -177,6 +179,7 @@ func newSession(proxy *Proxy, p *player.Player, client clientConn, backend Backe
 		proxy: proxy, player: p, client: client, backend: backend,
 		clientRuntimeID: data.EntityRuntimeID, clientUniqueID: data.EntityUniqueID,
 		clientDimension: data.Dimension,
+		state:           newBackendStateTracker(),
 	}
 }
 
@@ -257,8 +260,10 @@ func (s *session) backendLoop(ctx context.Context) error {
 		ctx := playercontext.NewHandlePacketContext(&pk)
 		s.player.HandleServerPacket(ctx)
 		if !ctx.Cancelled() {
-			s.rewriteServerPacket(*ctx.Packet())
-			err = s.client.WritePacket(*ctx.Packet())
+			if s.rewriteServerPacket(*ctx.Packet()) {
+				s.state.handle(*ctx.Packet())
+				err = s.client.WritePacket(*ctx.Packet())
+			}
 		}
 		s.routeMu.Unlock()
 		if err != nil {
@@ -289,6 +294,11 @@ func (s *session) transfer(ctx context.Context, address string) (bool, error) {
 }
 
 func (s *session) resetTransferState(state player.BackendTransferState) error {
+	for _, pk := range s.state.clearPackets() {
+		if err := s.client.WritePacket(pk); err != nil {
+			return err
+		}
+	}
 	for _, effectID := range state.EffectIDs {
 		if err := s.client.WritePacket(&packet.MobEffect{EntityRuntimeID: s.clientRuntimeID, Operation: packet.MobEffectRemove, EffectType: effectID}); err != nil {
 			return err
@@ -318,7 +328,12 @@ func transferResetPackets(currentDimension int32, data minecraft.GameData) []pac
 			break
 		}
 	}
-	packets := make([]packet.Packet, 0, 8)
+	packets := make([]packet.Packet, 0, 12)
+	packets = append(packets,
+		&packet.StopSound{StopAll: true},
+		&packet.LevelEvent{EventType: packet.LevelEventStopRaining, EventData: 10_000},
+		&packet.LevelEvent{EventType: packet.LevelEventStopThunderstorm},
+	)
 	if currentDimension == data.Dimension {
 		packets = append(packets,
 			&packet.ChangeDimension{Dimension: fakeDimension, Position: data.PlayerPosition},
@@ -331,8 +346,9 @@ func transferResetPackets(currentDimension int32, data minecraft.GameData) []pac
 		&packet.PlayStatus{Status: packet.PlayStatusPlayerSpawn},
 		&packet.PlayerAction{EntityRuntimeID: data.EntityRuntimeID, ActionType: protocol.PlayerActionDimensionChangeDone},
 		&packet.SetPlayerGameType{GameType: data.PlayerGameMode},
+		&packet.SetDifficulty{Difficulty: uint32(data.Difficulty)},
 		&packet.GameRulesChanged{GameRules: data.GameRules},
-		&packet.MovePlayer{EntityRuntimeID: data.EntityRuntimeID, Position: data.PlayerPosition, Mode: packet.MoveModeReset},
+		&packet.MovePlayer{EntityRuntimeID: data.EntityRuntimeID, Position: data.PlayerPosition, Pitch: data.Pitch, Yaw: data.Yaw, HeadYaw: data.Yaw, Mode: packet.MoveModeReset},
 	)
 	return packets
 }
@@ -395,12 +411,18 @@ func (s *session) rewriteClientPacket(pk packet.Packet) {
 			pk.EntityRuntimeID = to
 		}
 	case *packet.Interact:
-		if pk.TargetEntityRuntimeID == from {
+		if pk.TargetEntityRuntimeID == math.MaxInt64 {
+			pk.TargetEntityRuntimeID = from
+		} else if pk.TargetEntityRuntimeID == from {
 			pk.TargetEntityRuntimeID = to
 		}
 	case *packet.InventoryTransaction:
-		if tx, ok := pk.TransactionData.(*protocol.UseItemOnEntityTransactionData); ok && tx.TargetEntityRuntimeID == from {
-			tx.TargetEntityRuntimeID = to
+		if tx, ok := pk.TransactionData.(*protocol.UseItemOnEntityTransactionData); ok {
+			if tx.TargetEntityRuntimeID == math.MaxInt64 {
+				tx.TargetEntityRuntimeID = from
+			} else if tx.TargetEntityRuntimeID == from {
+				tx.TargetEntityRuntimeID = to
+			}
 		}
 	case *packet.ContainerOpen:
 		if pk.ContainerEntityUniqueID == s.clientUniqueID {
@@ -409,64 +431,68 @@ func (s *session) rewriteClientPacket(pk packet.Packet) {
 	}
 }
 
-func (s *session) rewriteServerPacket(pk packet.Packet) {
+func (s *session) rewriteServerPacket(pk packet.Packet) bool {
 	from, to := s.player.RuntimeId, s.clientRuntimeID
-	switch pk := pk.(type) {
-	case *packet.MovePlayer:
-		if pk.EntityRuntimeID == from {
-			pk.EntityRuntimeID = to
-		}
-	case *packet.MobEquipment:
-		if pk.EntityRuntimeID == from {
-			pk.EntityRuntimeID = to
-		}
-	case *packet.Animate:
-		if pk.EntityRuntimeID == from {
-			pk.EntityRuntimeID = to
-		}
-	case *packet.ActorEvent:
-		if pk.EntityRuntimeID == from {
-			pk.EntityRuntimeID = to
-		}
-	case *packet.PlayerAction:
-		if pk.EntityRuntimeID == from {
-			pk.EntityRuntimeID = to
-		}
-	case *packet.SetActorData:
-		if pk.EntityRuntimeID == from {
-			pk.EntityRuntimeID = to
-		}
-	case *packet.SetActorMotion:
-		if pk.EntityRuntimeID == from {
-			pk.EntityRuntimeID = to
-		}
-	case *packet.UpdateAttributes:
-		if pk.EntityRuntimeID == from {
-			pk.EntityRuntimeID = to
-		}
-	case *packet.MobEffect:
-		if pk.EntityRuntimeID == from {
-			pk.EntityRuntimeID = to
-		}
-	case *packet.Respawn:
-		if pk.EntityRuntimeID == from {
-			pk.EntityRuntimeID = to
-		}
-	case *packet.MobArmourEquipment:
-		if pk.EntityRuntimeID == from {
-			pk.EntityRuntimeID = to
-		}
-	case *packet.UpdateAbilities:
-		if pk.AbilityData.EntityUniqueID == s.player.UniqueId {
-			pk.AbilityData.EntityUniqueID = s.clientUniqueID
-		}
-	case *packet.ContainerOpen:
-		if pk.ContainerEntityUniqueID == s.player.UniqueId {
-			pk.ContainerEntityUniqueID = s.clientUniqueID
-		}
-	case *packet.RemoveActor:
-		if pk.EntityUniqueID == s.player.UniqueId {
-			pk.EntityUniqueID = s.clientUniqueID
+	rewriteRuntimeID := func(id *uint64) {
+		if *id == from {
+			*id = to
+		} else if from != to && *id == to {
+			*id = math.MaxInt64
 		}
 	}
+	rewriteUniqueID := func(id *int64) {
+		if *id == s.player.UniqueId {
+			*id = s.clientUniqueID
+		} else if s.player.UniqueId != s.clientUniqueID && *id == s.clientUniqueID {
+			*id = math.MaxInt64
+		}
+	}
+	switch pk := pk.(type) {
+	case *packet.AddPlayer:
+		if pk.EntityRuntimeID == from {
+			return false
+		}
+		rewriteRuntimeID(&pk.EntityRuntimeID)
+		rewriteUniqueID(&pk.AbilityData.EntityUniqueID)
+	case *packet.AddActor:
+		if pk.EntityRuntimeID == from {
+			return false
+		}
+		rewriteRuntimeID(&pk.EntityRuntimeID)
+		rewriteUniqueID(&pk.EntityUniqueID)
+	case *packet.AddItemActor:
+		rewriteRuntimeID(&pk.EntityRuntimeID)
+		rewriteUniqueID(&pk.EntityUniqueID)
+	case *packet.MoveActorAbsolute:
+		rewriteRuntimeID(&pk.EntityRuntimeID)
+	case *packet.MovePlayer:
+		rewriteRuntimeID(&pk.EntityRuntimeID)
+	case *packet.MobEquipment:
+		rewriteRuntimeID(&pk.EntityRuntimeID)
+	case *packet.Animate:
+		rewriteRuntimeID(&pk.EntityRuntimeID)
+	case *packet.ActorEvent:
+		rewriteRuntimeID(&pk.EntityRuntimeID)
+	case *packet.PlayerAction:
+		rewriteRuntimeID(&pk.EntityRuntimeID)
+	case *packet.SetActorData:
+		rewriteRuntimeID(&pk.EntityRuntimeID)
+	case *packet.SetActorMotion:
+		rewriteRuntimeID(&pk.EntityRuntimeID)
+	case *packet.UpdateAttributes:
+		rewriteRuntimeID(&pk.EntityRuntimeID)
+	case *packet.MobEffect:
+		rewriteRuntimeID(&pk.EntityRuntimeID)
+	case *packet.Respawn:
+		rewriteRuntimeID(&pk.EntityRuntimeID)
+	case *packet.MobArmourEquipment:
+		rewriteRuntimeID(&pk.EntityRuntimeID)
+	case *packet.UpdateAbilities:
+		rewriteUniqueID(&pk.AbilityData.EntityUniqueID)
+	case *packet.ContainerOpen:
+		rewriteUniqueID(&pk.ContainerEntityUniqueID)
+	case *packet.RemoveActor:
+		rewriteUniqueID(&pk.EntityUniqueID)
+	}
+	return true
 }

--- a/integration/proxy/proxy_test.go
+++ b/integration/proxy/proxy_test.go
@@ -3,10 +3,12 @@ package proxy
 import (
 	"errors"
 	"log/slog"
+	"math"
 	"net"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/oomph-ac/oomph/player"
 	"github.com/oomph-ac/oomph/player/component"
 	"github.com/sandertv/gophertunnel/minecraft"
@@ -47,12 +49,24 @@ func TestRuntimeIDRewritePreservesClientIdentityAcrossBackendSwap(t *testing.T) 
 }
 
 func TestTransferResetsClientWorldAcrossBackendDimensions(t *testing.T) {
-	data := minecraft.GameData{Dimension: packet.DimensionOverworld}
+	data := minecraft.GameData{Dimension: packet.DimensionOverworld, Difficulty: 3, Pitch: 12, Yaw: 34}
 	packets := transferResetPackets(packet.DimensionOverworld, data)
 	var changes []*packet.ChangeDimension
+	var stoppedSounds, stoppedRain, stoppedThunder, setDifficulty, resetRotation bool
 	for _, pk := range packets {
-		if change, ok := pk.(*packet.ChangeDimension); ok {
+		switch pk := pk.(type) {
+		case *packet.ChangeDimension:
+			change := pk
 			changes = append(changes, change)
+		case *packet.StopSound:
+			stoppedSounds = pk.StopAll
+		case *packet.LevelEvent:
+			stoppedRain = stoppedRain || pk.EventType == packet.LevelEventStopRaining && pk.EventData == 10_000
+			stoppedThunder = stoppedThunder || pk.EventType == packet.LevelEventStopThunderstorm
+		case *packet.SetDifficulty:
+			setDifficulty = pk.Difficulty == uint32(data.Difficulty)
+		case *packet.MovePlayer:
+			resetRotation = pk.Pitch == data.Pitch && pk.Yaw == data.Yaw
 		}
 	}
 	if len(changes) != 2 {
@@ -60,6 +74,63 @@ func TestTransferResetsClientWorldAcrossBackendDimensions(t *testing.T) {
 	}
 	if changes[0].Dimension == packet.DimensionOverworld || changes[1].Dimension != packet.DimensionOverworld {
 		t.Fatalf("dimension reset sequence = %d -> %d", changes[0].Dimension, changes[1].Dimension)
+	}
+	if !stoppedSounds || !stoppedRain || !stoppedThunder || !setDifficulty || !resetRotation {
+		t.Fatalf("destination reset missing: sounds=%t rain=%t thunder=%t difficulty=%t rotation=%t", stoppedSounds, stoppedRain, stoppedThunder, setDifficulty, resetRotation)
+	}
+}
+
+func TestBackendStateTrackerClearsSpectrumTransferState(t *testing.T) {
+	entryID := uuid.New()
+	tracker := newBackendStateTracker()
+	tracker.handle(&packet.AddActor{EntityUniqueID: 11})
+	tracker.handle(&packet.AddItemActor{EntityUniqueID: 12})
+	tracker.handle(&packet.AddPainting{EntityUniqueID: 13})
+	tracker.handle(&packet.BossEvent{BossEntityUniqueID: 14, EventType: packet.BossEventShow})
+	tracker.handle(&packet.PlayerList{ActionType: packet.PlayerListActionAdd, Entries: []protocol.PlayerListEntry{{UUID: entryID}}})
+	tracker.handle(&packet.SetDisplayObjective{ObjectiveName: "kills"})
+
+	packets := tracker.clearPackets()
+	var entities, bossBars, players, objectives int
+	for _, pk := range packets {
+		switch pk := pk.(type) {
+		case *packet.RemoveActor:
+			if pk.EntityUniqueID >= 11 && pk.EntityUniqueID <= 13 {
+				entities++
+			}
+		case *packet.BossEvent:
+			if pk.BossEntityUniqueID == 14 && pk.EventType == packet.BossEventHide {
+				bossBars++
+			}
+		case *packet.PlayerList:
+			if pk.ActionType == packet.PlayerListActionRemove && len(pk.Entries) == 1 && pk.Entries[0].UUID == entryID {
+				players++
+			}
+		case *packet.RemoveObjective:
+			if pk.ObjectiveName == "kills" {
+				objectives++
+			}
+		}
+	}
+	if entities != 3 || bossBars != 1 || players != 1 || objectives != 1 {
+		t.Fatalf("clear packets: entities=%d bossBars=%d players=%d objectives=%d", entities, bossBars, players, objectives)
+	}
+	if packets := tracker.clearPackets(); len(packets) != 0 {
+		t.Fatalf("second clear emitted %d stale packets", len(packets))
+	}
+}
+
+func TestBackendStateTrackerHonoursRemovalPackets(t *testing.T) {
+	entryID := uuid.New()
+	tracker := newBackendStateTracker()
+	tracker.handle(&packet.AddActor{EntityUniqueID: 11})
+	tracker.handle(&packet.RemoveActor{EntityUniqueID: 11})
+	tracker.handle(&packet.PlayerList{ActionType: packet.PlayerListActionAdd, Entries: []protocol.PlayerListEntry{{UUID: entryID}}})
+	tracker.handle(&packet.PlayerList{ActionType: packet.PlayerListActionRemove, Entries: []protocol.PlayerListEntry{{UUID: entryID}}})
+	tracker.handle(&packet.SetDisplayObjective{ObjectiveName: "kills"})
+	tracker.handle(&packet.RemoveObjective{ObjectiveName: "kills"})
+	if packets := tracker.clearPackets(); len(packets) != 0 {
+		t.Fatalf("clear emitted %d packets for removed state", len(packets))
 	}
 }
 
@@ -70,6 +141,31 @@ func TestRuntimeIDRewriteCoversSelfActorPackets(t *testing.T) {
 	s.rewriteServerPacket(pk)
 	if pk.EntityRuntimeID != 1 {
 		t.Fatalf("ActorEvent runtime ID = %d, want stable client ID 1", pk.EntityRuntimeID)
+	}
+}
+
+func TestRuntimeIDRewriteAvoidsBackendEntityCollision(t *testing.T) {
+	p := &player.Player{RuntimeId: 27}
+	s := &session{player: p, clientRuntimeID: 1}
+	pk := &packet.MoveActorAbsolute{EntityRuntimeID: 1}
+	if !s.rewriteServerPacket(pk) {
+		t.Fatal("collision packet was suppressed")
+	}
+	if pk.EntityRuntimeID != math.MaxInt64 {
+		t.Fatalf("collision runtime ID = %d, want sentinel %d", pk.EntityRuntimeID, int64(math.MaxInt64))
+	}
+	clientPacket := &packet.Interact{TargetEntityRuntimeID: math.MaxInt64}
+	s.rewriteClientPacket(clientPacket)
+	if clientPacket.TargetEntityRuntimeID != 1 {
+		t.Fatalf("collision target runtime ID = %d, want backend entity ID 1", clientPacket.TargetEntityRuntimeID)
+	}
+}
+
+func TestRuntimeIDRewriteSuppressesBackendSelfSpawn(t *testing.T) {
+	p := &player.Player{RuntimeId: 27}
+	s := &session{player: p, clientRuntimeID: 1}
+	if s.rewriteServerPacket(&packet.AddActor{EntityRuntimeID: 27}) {
+		t.Fatal("backend self AddActor was forwarded")
 	}
 }
 
@@ -92,6 +188,7 @@ func TestTransferDoesNotReportSuccessWhenStateSyncFails(t *testing.T) {
 	s := &session{
 		player: p, client: &fakeClient{}, backend: backend,
 		clientRuntimeID: 1, clientUniqueID: 2,
+		state: newBackendStateTracker(),
 	}
 	if err := s.resetTransferState(player.BackendTransferState{}); !errors.Is(err, want) {
 		t.Fatalf("resetTransferState() error = %v, want %v", err, want)
@@ -127,10 +224,15 @@ func (*fakeBackend) DoSpawn() error                     { return nil }
 func (f *fakeBackend) Flush() error                     { return f.flushErr }
 func (*fakeBackend) Close() error                       { return nil }
 
-type fakeClient struct{}
+type fakeClient struct {
+	packets []packet.Packet
+}
 
 func (*fakeClient) ReadPacket() (packet.Packet, error) { return nil, errors.New("unused") }
-func (*fakeClient) WritePacket(packet.Packet) error    { return nil }
+func (f *fakeClient) WritePacket(pk packet.Packet) error {
+	f.packets = append(f.packets, pk)
+	return nil
+}
 func (*fakeClient) StartGame(minecraft.GameData) error { return nil }
 func (*fakeClient) RemoteAddr() net.Addr               { return nil }
 func (*fakeClient) Close() error                       { return nil }

--- a/integration/proxy/proxy_test.go
+++ b/integration/proxy/proxy_test.go
@@ -145,8 +145,8 @@ func TestRuntimeIDRewriteCoversSelfActorPackets(t *testing.T) {
 }
 
 func TestRuntimeIDRewriteAvoidsBackendEntityCollision(t *testing.T) {
-	p := &player.Player{RuntimeId: 27}
-	s := &session{player: p, clientRuntimeID: 1}
+	p := &player.Player{RuntimeId: 27, UniqueId: 84}
+	s := &session{player: p, clientRuntimeID: 1, clientUniqueID: 2}
 	pk := &packet.MoveActorAbsolute{EntityRuntimeID: 1}
 	if !s.rewriteServerPacket(pk) {
 		t.Fatal("collision packet was suppressed")
@@ -158,6 +158,11 @@ func TestRuntimeIDRewriteAvoidsBackendEntityCollision(t *testing.T) {
 	s.rewriteClientPacket(clientPacket)
 	if clientPacket.TargetEntityRuntimeID != 1 {
 		t.Fatalf("collision target runtime ID = %d, want backend entity ID 1", clientPacket.TargetEntityRuntimeID)
+	}
+	painting := &packet.AddPainting{EntityRuntimeID: 1, EntityUniqueID: 2}
+	s.rewriteServerPacket(painting)
+	if painting.EntityRuntimeID != math.MaxInt64 || painting.EntityUniqueID != math.MaxInt64 {
+		t.Fatalf("painting collision IDs = %d/%d, want sentinel", painting.EntityRuntimeID, painting.EntityUniqueID)
 	}
 }
 

--- a/integration/proxy/state_tracker.go
+++ b/integration/proxy/state_tracker.go
@@ -1,0 +1,84 @@
+package proxy
+
+import (
+	"github.com/google/uuid"
+	"github.com/sandertv/gophertunnel/minecraft/protocol"
+	"github.com/sandertv/gophertunnel/minecraft/protocol/packet"
+)
+
+// backendStateTracker records client-visible state that survives a dimension
+// change and must therefore be explicitly removed before another backend takes
+// ownership of the session.
+type backendStateTracker struct {
+	bossBars    map[int64]struct{}
+	entities    map[int64]struct{}
+	players     map[uuid.UUID]struct{}
+	scoreboards map[string]struct{}
+}
+
+func newBackendStateTracker() *backendStateTracker {
+	return &backendStateTracker{
+		bossBars:    map[int64]struct{}{},
+		entities:    map[int64]struct{}{},
+		players:     map[uuid.UUID]struct{}{},
+		scoreboards: map[string]struct{}{},
+	}
+}
+
+func (t *backendStateTracker) handle(pk packet.Packet) {
+	switch pk := pk.(type) {
+	case *packet.AddActor:
+		t.entities[pk.EntityUniqueID] = struct{}{}
+	case *packet.AddItemActor:
+		t.entities[pk.EntityUniqueID] = struct{}{}
+	case *packet.AddPainting:
+		t.entities[pk.EntityUniqueID] = struct{}{}
+	case *packet.AddPlayer:
+		t.entities[pk.AbilityData.EntityUniqueID] = struct{}{}
+	case *packet.RemoveActor:
+		delete(t.entities, pk.EntityUniqueID)
+	case *packet.BossEvent:
+		if pk.EventType == packet.BossEventHide {
+			delete(t.bossBars, pk.BossEntityUniqueID)
+		} else {
+			t.bossBars[pk.BossEntityUniqueID] = struct{}{}
+		}
+	case *packet.PlayerList:
+		for _, entry := range pk.Entries {
+			if pk.ActionType == packet.PlayerListActionAdd {
+				t.players[entry.UUID] = struct{}{}
+			} else {
+				delete(t.players, entry.UUID)
+			}
+		}
+	case *packet.SetDisplayObjective:
+		t.scoreboards[pk.ObjectiveName] = struct{}{}
+	case *packet.RemoveObjective:
+		delete(t.scoreboards, pk.ObjectiveName)
+	}
+}
+
+func (t *backendStateTracker) clearPackets() []packet.Packet {
+	packets := make([]packet.Packet, 0, len(t.entities)+len(t.bossBars)+len(t.scoreboards)+1)
+	for id := range t.entities {
+		packets = append(packets, &packet.RemoveActor{EntityUniqueID: id})
+	}
+	for id := range t.bossBars {
+		packets = append(packets, &packet.BossEvent{BossEntityUniqueID: id, EventType: packet.BossEventHide})
+	}
+	if len(t.players) != 0 {
+		entries := make([]protocol.PlayerListEntry, 0, len(t.players))
+		for id := range t.players {
+			entries = append(entries, protocol.PlayerListEntry{UUID: id})
+		}
+		packets = append(packets, &packet.PlayerList{ActionType: packet.PlayerListActionRemove, Entries: entries})
+	}
+	for objective := range t.scoreboards {
+		packets = append(packets, &packet.RemoveObjective{ObjectiveName: objective})
+	}
+	clear(t.entities)
+	clear(t.bossBars)
+	clear(t.players)
+	clear(t.scoreboards)
+	return packets
+}


### PR DESCRIPTION
## Summary
- track and clear backend entities, boss bars, player-list entries, and scoreboard objectives during native transfers
- reset sounds, weather, difficulty, rotation, game mode, and game rules from destination game data
- complete runtime/unique ID collision handling and suppress duplicate backend self-spawns

## Verification
- `go test -race ./...`
- `go vet ./...`
- `go test ./... && go vet ./...` in `example/default`
- `go test ./... && go vet ./...` in `example/dragonfly`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the hot path for every server→client packet and transfer synchronization; incorrect rewriting or cleanup could cause ghost entities, broken interactions, or inconsistent client state after transfers.
> 
> **Overview**
> Aligns the native RakNet proxy’s **backend transfer** path with fuller client reset behavior and safer entity ID rewriting.
> 
> A new **`backendStateTracker`** records client-visible state from forwarded server packets (spawned entities, boss bars, tab-list players, scoreboard objectives) and **`resetTransferState`** now flushes matching teardown packets before the existing mob-effect and dimension reset sequence. **`transferResetPackets`** additionally stops all sounds and weather, restores **difficulty**, and resets **pitch/yaw** on `MovePlayer`.
> 
> **`rewriteServerPacket`** now returns whether to forward the packet: backend **self** `AddActor`/`AddPlayer` spawns are dropped, and runtime/unique ID rewrites use a **`math.MaxInt64` sentinel** when backend IDs would collide with the stable client identity (with inverse handling on client `Interact` / use-on-entity transactions). Coverage is extended to more entity-related packet types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c86550c447bb6efa724cd0a962f0d49606f9930c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced cross-dimension backend transfers by tracking and clearing client-visible state (entities, boss bars, player list entries, and scoreboard objectives).
* **Bug Fixes**
  * Improved world reset behavior to stop all sounds, end rain/thunder effects, apply difficulty changes, and restore player pitch/yaw.
  * Strengthened entity targeting/ID rewriting to avoid collisions and suppress unintended backend-originated self-spawns.
* **Tests**
  * Expanded integration coverage for transfer clearing, runtime ID rewrite edge cases, and backend state tracker behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->