### PR TITLE
feat: support block state hashes for network block IDs

### DIFF
--- a/player/component/acknowledgement/chunks.go
+++ b/player/component/acknowledgement/chunks.go
@@ -29,7 +29,7 @@ func (ack *ChunkUpdate) Run() {
 		ack.mPlayer.Disconnect(game.ErrorChunkCacheUnsupported)
 		return
 	}
-	cInfo, err := oworld.CacheChunk(ack.pk)
+	cInfo, err := oworld.CacheChunk(ack.pk, ack.mPlayer.BlockNetworkIDsHashed())
 	if err != nil {
 		ack.mPlayer.Disconnect(fmt.Sprintf(game.ErrorInternalDecodeChunk, err))
 		return
@@ -93,7 +93,7 @@ func (ack *SubChunkUpdate) Run() {
 			bufUsed = true
 			buf.Write(entry.RawPayload)
 
-			cachedSub, err := oworld.CacheSubChunk(buf, ch, chunkPos)
+			cachedSub, err := oworld.CacheSubChunk(buf, ch, chunkPos, ack.mPlayer.BlockNetworkIDsHashed())
 			if err != nil {
 				ack.mPlayer.Disconnect(fmt.Sprintf(game.ErrorInternalDecodeChunk, err))
 				continue

--- a/player/component/world.go
+++ b/player/component/world.go
@@ -14,6 +14,7 @@ import (
 	"github.com/oomph-ac/oomph/player"
 	"github.com/oomph-ac/oomph/player/component/acknowledgement"
 	"github.com/oomph-ac/oomph/utils"
+	oworld "github.com/oomph-ac/oomph/world"
 	"github.com/sandertv/gophertunnel/minecraft/protocol"
 	"github.com/sandertv/gophertunnel/minecraft/protocol/packet"
 )
@@ -77,7 +78,8 @@ func (c *WorldUpdaterComponent) HandleUpdateBlock(pk *packet.UpdateBlock) {
 		c.mPlayer.Log().Debug("unsupported layer update block", "layer", pk.Layer, "block", pk.NewBlockRuntimeID, "pos", pos)
 		return
 	}
-	c.AddPendingUpdate(pos, pk.NewBlockRuntimeID)
+	useHashes := c.mPlayer.BlockNetworkIDsHashed()
+	c.AddPendingUpdate(pos, oworld.NetworkBlockIDToRuntimeID(pk.NewBlockRuntimeID, useHashes))
 }
 
 // HandleUpdateSubChunkBlocks handles an UpdateSubChunkBlocks packet from the server.
@@ -85,11 +87,12 @@ func (c *WorldUpdaterComponent) HandleUpdateSubChunkBlocks(pk *packet.UpdateSubC
 	if !c.mPlayer.Ready {
 		c.mPlayer.ACKs().Add(acknowledgement.NewPlayerInitalizedACK(c.mPlayer))
 	}
+	useHashes := c.mPlayer.BlockNetworkIDsHashed()
 	for _, entry := range pk.Blocks {
-		c.AddPendingUpdate(df_cube.Pos{int(entry.BlockPos.X()), int(entry.BlockPos.Y()), int(entry.BlockPos.Z())}, entry.BlockRuntimeID)
+		c.AddPendingUpdate(df_cube.Pos{int(entry.BlockPos.X()), int(entry.BlockPos.Y()), int(entry.BlockPos.Z())}, oworld.NetworkBlockIDToRuntimeID(entry.BlockRuntimeID, useHashes))
 	}
 	for _, entry := range pk.Extra {
-		c.AddPendingUpdate(df_cube.Pos{int(entry.BlockPos.X()), int(entry.BlockPos.Y()), int(entry.BlockPos.Z())}, entry.BlockRuntimeID)
+		c.AddPendingUpdate(df_cube.Pos{int(entry.BlockPos.X()), int(entry.BlockPos.Y()), int(entry.BlockPos.Z())}, oworld.NetworkBlockIDToRuntimeID(entry.BlockRuntimeID, useHashes))
 	}
 }
 
@@ -188,7 +191,8 @@ func (c *WorldUpdaterComponent) AttemptItemInteractionWithBlock(pk *packet.Inven
 	case *block.Air:
 		// This only happens when Dragonfly is unsure of what the item is (unregistered), so we use the client-authoritative block in hand.
 		c.mPlayer.Dbg.Notify(player.DebugModeBlockPlacement, true, "called c.mPlayer.PlaceBlock: using client-authoritative block in hand")
-		if b, ok := df_world.BlockByRuntimeID(uint32(dat.HeldItem.Stack.BlockRuntimeID)); ok {
+		heldBlockRID := oworld.NetworkBlockIDToRuntimeID(uint32(dat.HeldItem.Stack.BlockRuntimeID), c.mPlayer.BlockNetworkIDsHashed())
+		if b, ok := df_world.BlockByRuntimeID(heldBlockRID); ok {
 			c.mPlayer.Dbg.Notify(player.DebugModeBlockPlacement, true, "placing block with runtime ID: %d", dat.HeldItem.Stack.BlockRuntimeID)
 
 			// If the block at the position is not replacable, we want to place the block on the side of the block.

--- a/player/items.go
+++ b/player/items.go
@@ -5,6 +5,7 @@ import (
 	"github.com/df-mc/dragonfly/server/item"
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/oomph-ac/oomph/utils"
+	oworld "github.com/oomph-ac/oomph/world"
 	"github.com/sandertv/gophertunnel/minecraft/protocol"
 
 	_ "unsafe"
@@ -19,7 +20,7 @@ func (p *Player) ConvertToStack(it protocol.ItemStack) item.Stack {
 		}
 	}
 	if it.BlockRuntimeID > 0 {
-		b, _ := p.World().BlockRegistry().BlockByRuntimeID(uint32(it.BlockRuntimeID))
+		b, _ := p.World().BlockRegistry().BlockByRuntimeID(oworld.NetworkBlockIDToRuntimeID(uint32(it.BlockRuntimeID), p.BlockNetworkIDsHashed()))
 		if t, ok = b.(world.Item); !ok {
 			t = block.Air{}
 		}
@@ -32,10 +33,21 @@ func (p *Player) ConvertToStack(it protocol.ItemStack) item.Stack {
 }
 
 func (p *Player) InstanceFromItem(it item.Stack) protocol.ItemInstance {
-	return utils.InstanceFromItem(p.World().BlockRegistry(), it)
+	inst := utils.InstanceFromItem(p.World().BlockRegistry(), it)
+	// The block runtime ID embedded in an item instance is a network block ID. When the session uses block
+	// network ID hashes, convert the dragonfly runtime ID to its hash before it is sent to the client.
+	if p.BlockNetworkIDsHashed() && inst.Stack.BlockRuntimeID != 0 {
+		inst.Stack.BlockRuntimeID = int32(oworld.RuntimeIDToNetworkBlockID(uint32(inst.Stack.BlockRuntimeID), true))
+	}
+	return inst
 }
 
 func (p *Player) StackToItem(it protocol.ItemStack) item.Stack {
+	// The block runtime ID of an item stack received over the network is a network block ID. Convert it to a
+	// dragonfly runtime ID when the session uses block network ID hashes.
+	if p.BlockNetworkIDsHashed() && it.BlockRuntimeID != 0 {
+		it.BlockRuntimeID = int32(oworld.NetworkBlockIDToRuntimeID(uint32(it.BlockRuntimeID), true))
+	}
 	return utils.StackToItem(p.World().BlockRegistry(), it)
 }
 

--- a/player/network.go
+++ b/player/network.go
@@ -16,6 +16,13 @@ func (p *Player) Conn() *minecraft.Conn {
 	return p.conn
 }
 
+// BlockNetworkIDsHashed returns whether block network IDs on this session are block state hashes rather than
+// runtime IDs. This is negotiated by the server via the UseBlockNetworkIDHashes field of the StartGame packet
+// and applies to every packet carrying block network IDs (chunks, block updates, item stacks, etc.).
+func (p *Player) BlockNetworkIDsHashed() bool {
+	return p.GameDat.UseBlockNetworkIDHashes
+}
+
 // ServerConn returns the connection to the server.
 func (p *Player) ServerConn() ServerConn {
 	return p.serverConn

--- a/player/world.go
+++ b/player/world.go
@@ -99,7 +99,7 @@ func (p *Player) SyncBlock(pos df_cube.Pos) {
 			int32(pos[1]),
 			int32(pos[2]),
 		},
-		NewBlockRuntimeID: world.BlockRuntimeID(p.World().Block(pos)),
+		NewBlockRuntimeID: oworld.RuntimeIDToNetworkBlockID(world.BlockRuntimeID(p.World().Block(pos)), p.BlockNetworkIDsHashed()),
 		Flags:             packet.BlockUpdateNetwork,
 		Layer:             0, // TODO: Implement and account for multi-layer blocks.
 	}
@@ -166,11 +166,11 @@ func (p *Player) SendBlockUpdates(positions []protocol.BlockPos) {
 	for _, pos := range positions {
 		p.SendPacketToClient(&packet.UpdateBlock{
 			Position: pos,
-			NewBlockRuntimeID: world.BlockRuntimeID(p.World().Block(df_cube.Pos{
+			NewBlockRuntimeID: oworld.RuntimeIDToNetworkBlockID(world.BlockRuntimeID(p.World().Block(df_cube.Pos{
 				int(pos.X()),
 				int(pos.Y()),
 				int(pos.Z()),
-			})),
+			})), p.BlockNetworkIDsHashed()),
 			Flags: packet.BlockUpdateNeighbours,
 			Layer: 0, // TODO: Implement and account for multi-layer blocks.
 		})

--- a/world/cache.go
+++ b/world/cache.go
@@ -47,7 +47,7 @@ func unsubSC(hash xxh3.Uint128) {
 	}
 }
 
-func CacheSubChunk(payload *bytes.Buffer, c *chunk.Chunk, pos protocol.ChunkPos) (*CachedSubChunk, error) {
+func CacheSubChunk(payload *bytes.Buffer, c *chunk.Chunk, pos protocol.ChunkPos, useHashes bool) (*CachedSubChunk, error) {
 	scMu.Lock()
 	defer scMu.Unlock()
 
@@ -63,6 +63,11 @@ func CacheSubChunk(payload *bytes.Buffer, c *chunk.Chunk, pos protocol.ChunkPos)
 	if err != nil {
 		return nil, err
 	}
+	// When the connection uses block network ID hashes, the decoded palettes contain block state hashes rather
+	// than runtime IDs. Convert them back so the rest of oomph can treat the sub chunk like any other.
+	if useHashes {
+		convertSubChunkHashPalettes(decodedSC)
+	}
 
 	cachedSC := &CachedSubChunk{hash: hash, layer: index, sc: decodedSC}
 	cachedSC.subs.Add(1)
@@ -72,7 +77,7 @@ func CacheSubChunk(payload *bytes.Buffer, c *chunk.Chunk, pos protocol.ChunkPos)
 	return cachedSC, nil
 }
 
-func CacheChunk(input *packet.LevelChunk) (ChunkInfo, error) {
+func CacheChunk(input *packet.LevelChunk, useHashes bool) (ChunkInfo, error) {
 	cMu.Lock()
 	defer cMu.Unlock()
 
@@ -96,6 +101,11 @@ func CacheChunk(input *packet.LevelChunk) (ChunkInfo, error) {
 	)
 	if err != nil {
 		return ChunkInfo{}, err
+	}
+	// When the connection uses block network ID hashes, the decoded palettes contain block state hashes rather
+	// than runtime IDs. Convert them before compacting so air is recognised and the chunk behaves normally.
+	if useHashes {
+		convertHashPalettesToRuntimeIDs(decodedChunk)
 	}
 	decodedChunk.Compact()
 

--- a/world/hash.go
+++ b/world/hash.go
@@ -1,0 +1,59 @@
+package world
+
+import "github.com/df-mc/dragonfly/server/world/chunk"
+
+// NetworkBlockIDToRuntimeID converts a block network ID received over the network into a dragonfly runtime ID.
+// When useHashes is true, the network ID is a block state hash (as negotiated via the StartGame
+// UseBlockNetworkIDHashes field) and is resolved to its runtime ID. Otherwise the network ID is already a
+// runtime ID and is returned unchanged. Unknown hashes resolve to air.
+func NetworkBlockIDToRuntimeID(networkID uint32, useHashes bool) uint32 {
+	if !useHashes {
+		return networkID
+	}
+	if rid, ok := BlockRegistry.HashToRuntimeID(networkID); ok {
+		return rid
+	}
+	return AirRuntimeID
+}
+
+// RuntimeIDToNetworkBlockID converts a dragonfly runtime ID into the block network ID that should be written
+// to a connection. When useHashes is true, the runtime ID is converted to its block state hash. Otherwise the
+// runtime ID is returned unchanged. Runtime IDs without a known hash are returned unchanged.
+func RuntimeIDToNetworkBlockID(rid uint32, useHashes bool) uint32 {
+	if !useHashes {
+		return rid
+	}
+	if hash, ok := BlockRegistry.RuntimeIDToHash(rid); ok {
+		return hash
+	}
+	return rid
+}
+
+// convertHashPalettesToRuntimeIDs rewrites every block palette in the chunk so that block state hashes are
+// replaced with their corresponding dragonfly runtime IDs. It is used when a chunk is decoded from a connection
+// that uses block network ID hashes rather than runtime IDs.
+func convertHashPalettesToRuntimeIDs(c *chunk.Chunk) {
+	for _, sub := range c.Sub() {
+		if sub == nil {
+			continue
+		}
+		convertSubChunkHashPalettes(sub)
+	}
+}
+
+// convertSubChunkHashPalettes rewrites every block palette in the sub chunk, replacing block state hashes with
+// their corresponding dragonfly runtime IDs.
+func convertSubChunkHashPalettes(sub *chunk.SubChunk) {
+	for _, storage := range sub.Layers() {
+		if storage == nil {
+			continue
+		}
+		palette := storage.Palette()
+		if palette == nil {
+			continue
+		}
+		palette.Replace(func(v uint32) uint32 {
+			return NetworkBlockIDToRuntimeID(v, true)
+		})
+	}
+}

--- a/world/hash_test.go
+++ b/world/hash_test.go
@@ -1,0 +1,92 @@
+package world
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/df-mc/dragonfly/server/world"
+	"github.com/df-mc/dragonfly/server/world/chunk"
+	"github.com/sandertv/gophertunnel/minecraft/protocol/packet"
+)
+
+func TestNetworkBlockIDHashRoundTrip(t *testing.T) {
+	FinalizeBlockRegistry()
+
+	// Without hashes, network IDs are runtime IDs and pass through unchanged.
+	if got := NetworkBlockIDToRuntimeID(AirRuntimeID, false); got != AirRuntimeID {
+		t.Fatalf("expected passthrough %d, got %d", AirRuntimeID, got)
+	}
+	if got := RuntimeIDToNetworkBlockID(AirRuntimeID, false); got != AirRuntimeID {
+		t.Fatalf("expected passthrough %d, got %d", AirRuntimeID, got)
+	}
+
+	// With hashes, a runtime ID converts to a hash and back to the same runtime ID.
+	for _, rid := range []uint32{AirRuntimeID, 1, 100, 1000} {
+		hash := RuntimeIDToNetworkBlockID(rid, true)
+		back := NetworkBlockIDToRuntimeID(hash, true)
+		if back != rid {
+			t.Fatalf("round trip failed for rid %d: hash=%d back=%d", rid, hash, back)
+		}
+	}
+}
+
+// TestCacheChunkWithHashes verifies that a chunk encoded with block state hashes in its palette is decoded back
+// into a chunk whose blocks resolve to the correct dragonfly runtime IDs.
+func TestCacheChunkWithHashes(t *testing.T) {
+	FinalizeBlockRegistry()
+
+	stoneRID, ok := BlockRegistry.StateToRuntimeID("minecraft:stone", nil)
+	if !ok {
+		t.Fatal("could not resolve stone runtime ID")
+	}
+
+	rng := world.Overworld.Range()
+	c := chunk.New(BlockRegistry, rng)
+	c.SetBlock(0, int16(rng[0]), 0, 0, stoneRID)
+	c.SetBlock(5, int16(rng[0])+7, 3, 0, stoneRID)
+
+	// Rewrite the palettes so the encoded payload carries block state hashes rather than runtime IDs, exactly
+	// as a server with UseBlockNetworkIDHashes enabled would send them.
+	for _, sub := range c.Sub() {
+		if sub == nil {
+			continue
+		}
+		for _, storage := range sub.Layers() {
+			if storage == nil || storage.Palette() == nil {
+				continue
+			}
+			storage.Palette().Replace(func(v uint32) uint32 {
+				return RuntimeIDToNetworkBlockID(v, true)
+			})
+		}
+	}
+
+	serialised := chunk.Encode(c, chunk.NetworkEncoding)
+	buf := bytes.NewBuffer(nil)
+	for _, sub := range serialised.SubChunks {
+		buf.Write(sub)
+	}
+	buf.Write(serialised.Biomes)
+	buf.WriteByte(0)
+
+	pk := &packet.LevelChunk{
+		Dimension:     0,
+		SubChunkCount: uint32(len(serialised.SubChunks)),
+		RawPayload:    buf.Bytes(),
+	}
+
+	info, err := CacheChunk(pk, true)
+	if err != nil {
+		t.Fatalf("CacheChunk failed: %v", err)
+	}
+
+	if got := info.Chunk.Block(0, int16(rng[0]), 0, 0); got != stoneRID {
+		t.Fatalf("expected stone rid %d at origin, got %d", stoneRID, got)
+	}
+	if got := info.Chunk.Block(5, int16(rng[0])+7, 3, 0); got != stoneRID {
+		t.Fatalf("expected stone rid %d, got %d", stoneRID, got)
+	}
+	if got := info.Chunk.Block(1, int16(rng[0]), 0, 0); got != AirRuntimeID {
+		t.Fatalf("expected air rid %d for empty block, got %d", AirRuntimeID, got)
+	}
+}


### PR DESCRIPTION
## Summary

Adds support for the Bedrock `UseBlockNetworkIDHashes` StartGame flag. When a server negotiates this flag, block network IDs carried by chunks, block updates, and item stacks are **block state hashes** rather than dragonfly runtime IDs. Previously Oomph assumed runtime IDs everywhere, so on such servers its internal world model was populated with meaningless values, breaking block-aware checks (interaction/reach, block breaking, ghost-block handling, movement over blocks, etc.).

Oomph continues to use dragonfly runtime IDs internally; conversion happens only at the network boundary.

## Changes

- **`world/hash.go`** (new): `NetworkBlockIDToRuntimeID` / `RuntimeIDToNetworkBlockID` helpers (backed by the dragonfly registry's `HashToRuntimeID` / `RuntimeIDToHash`), plus palette-rewrite helpers for chunks and sub chunks.
- **`world/cache.go`**: `CacheChunk` and `CacheSubChunk` take a `useHashes` flag and convert decoded palettes hash → runtime ID (before `Compact()` so air is recognised).
- **`player/network.go`**: `Player.BlockNetworkIDsHashed()` reads the negotiated `GameData.UseBlockNetworkIDHashes`.
- **`player/component/world.go`**: `HandleUpdateBlock`, `HandleUpdateSubChunkBlocks`, and the client-authoritative held-block path convert incoming network IDs → runtime IDs.
- **`player/world.go`**: outgoing `UpdateBlock` packets to the client (`SyncBlock`, `SendBlockUpdates`) are encoded as network IDs (runtime ID → hash).
- **`player/items.go`**: item-stack block runtime IDs are converted in both directions (`ConvertToStack`, `StackToItem`, `InstanceFromItem`).
- **`player/component/acknowledgement/chunks.go`**: threads the flag into the cache calls.

## Testing

- `go build ./...` passes.
- Added `world/hash_test.go`: a hash round-trip test and an end-to-end test that encodes a chunk with a hash palette and verifies `CacheChunk(..., true)` decodes blocks back to their correct runtime IDs (including air for empty blocks).
- Full suite passes except two pre-existing integration tests that require outbound access to Minecraft's auth discovery service (unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjvWSJdWVCnmetHAtTKcGP

---
_Generated by [Claude Code](https://claude.ai/code/session_01LjvWSJdWVCnmetHAtTKcGP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for block state hash network IDs.
  * Improved block, item, chunk, and sub-chunk synchronization for sessions using hashed block IDs.
  * Unknown block hashes now safely resolve to air.

* **Bug Fixes**
  * Corrected block conversions during world updates, item handling, placement, and chunk caching.
  * Preserved consistent block state data between the client and server.

* **Tests**
  * Added coverage for block ID conversion and hashed chunk decoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->