### PR TITLE
Add reusable block network codecs

### DIFF
--- a/world/blocknetwork/codec.go
+++ b/world/blocknetwork/codec.go
@@ -26,7 +26,8 @@ func (c Codec) ToRuntimeID(networkID uint32) (uint32, bool) {
 	if c.mode == Hashes {
 		return c.registry.HashToRuntimeID(networkID)
 	}
-	return networkID, networkID < uint32(c.registry.BlockCount())
+	_, _, ok := c.registry.RuntimeIDToState(networkID)
+	return networkID, ok
 }
 
 // FromRuntimeID converts a canonical block-registry runtime ID to the codec's network representation.
@@ -34,7 +35,8 @@ func (c Codec) FromRuntimeID(runtimeID uint32) (uint32, bool) {
 	if c.mode == Hashes {
 		return c.registry.RuntimeIDToHash(runtimeID)
 	}
-	return runtimeID, runtimeID < uint32(c.registry.BlockCount())
+	_, _, ok := c.registry.RuntimeIDToState(runtimeID)
+	return runtimeID, ok
 }
 
 // Translator converts block IDs from one endpoint codec to another.

--- a/world/blocknetwork/codec.go
+++ b/world/blocknetwork/codec.go
@@ -1,0 +1,70 @@
+package blocknetwork
+
+import "github.com/df-mc/dragonfly/server/world/chunk"
+
+// Codec converts IDs used by one network endpoint to and from canonical block-registry runtime IDs.
+type Codec struct {
+	registry chunk.BlockRegistry
+	mode     Mode
+}
+
+// NewCodec returns a Codec backed by registry using mode. It panics if registry is nil.
+func NewCodec(registry chunk.BlockRegistry, mode Mode) Codec {
+	if registry == nil {
+		panic("blocknetwork: nil block registry")
+	}
+	return Codec{registry: registry, mode: mode}
+}
+
+// Mode returns the network representation used by the codec.
+func (c Codec) Mode() Mode {
+	return c.mode
+}
+
+// ToRuntimeID converts a network ID to a canonical block-registry runtime ID.
+func (c Codec) ToRuntimeID(networkID uint32) (uint32, bool) {
+	if c.mode == Hashes {
+		return c.registry.HashToRuntimeID(networkID)
+	}
+	return networkID, networkID < uint32(c.registry.BlockCount())
+}
+
+// FromRuntimeID converts a canonical block-registry runtime ID to the codec's network representation.
+func (c Codec) FromRuntimeID(runtimeID uint32) (uint32, bool) {
+	if c.mode == Hashes {
+		return c.registry.RuntimeIDToHash(runtimeID)
+	}
+	return runtimeID, runtimeID < uint32(c.registry.BlockCount())
+}
+
+// Translator converts block IDs from one endpoint codec to another.
+type Translator struct {
+	source Codec
+	target Codec
+}
+
+// NewTranslator returns a Translator that converts IDs from source to target.
+func NewTranslator(source, target Codec) Translator {
+	return Translator{source: source, target: target}
+}
+
+// Required reports whether source and target use different block ID representations.
+func (t Translator) Required() bool {
+	return t.source.Mode() != t.target.Mode()
+}
+
+// Translate converts a source network ID to the target representation. Unknown IDs are preserved.
+func (t Translator) Translate(networkID uint32) uint32 {
+	if !t.Required() {
+		return networkID
+	}
+	runtimeID, ok := t.source.ToRuntimeID(networkID)
+	if !ok {
+		return networkID
+	}
+	translated, ok := t.target.FromRuntimeID(runtimeID)
+	if !ok {
+		return networkID
+	}
+	return translated
+}

--- a/world/blocknetwork/codec_test.go
+++ b/world/blocknetwork/codec_test.go
@@ -1,0 +1,173 @@
+package blocknetwork_test
+
+import (
+	"math"
+	"os"
+	"testing"
+
+	"github.com/df-mc/dragonfly/server/block"
+	"github.com/oomph-ac/oomph/world"
+	"github.com/oomph-ac/oomph/world/blocknetwork"
+)
+
+func TestMain(m *testing.M) {
+	world.FinalizeBlockRegistry()
+	os.Exit(m.Run())
+}
+
+func TestModeFromHashes(t *testing.T) {
+	t.Parallel()
+
+	if got := blocknetwork.ModeFromHashes(false); got != blocknetwork.RuntimeIDs {
+		t.Fatalf("ModeFromHashes(false) = %v, want RuntimeIDs", got)
+	}
+	if got := blocknetwork.ModeFromHashes(true); got != blocknetwork.Hashes {
+		t.Fatalf("ModeFromHashes(true) = %v, want Hashes", got)
+	}
+}
+
+func TestCodecConvertsNetworkIDs(t *testing.T) {
+	t.Parallel()
+
+	runtimeID := world.BlockRegistry.BlockRuntimeID(block.Stone{})
+	networkHash, ok := world.BlockRegistry.RuntimeIDToHash(runtimeID)
+	if !ok {
+		t.Fatal("stone runtime ID has no network hash")
+	}
+
+	tests := []struct {
+		name      string
+		codec     blocknetwork.Codec
+		networkID uint32
+	}{
+		{name: "runtime IDs", codec: blocknetwork.NewCodec(world.BlockRegistry, blocknetwork.RuntimeIDs), networkID: runtimeID},
+		{name: "hashes", codec: blocknetwork.NewCodec(world.BlockRegistry, blocknetwork.Hashes), networkID: networkHash},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got, found := test.codec.ToRuntimeID(test.networkID); !found || got != runtimeID {
+				t.Fatalf("ToRuntimeID(%d) = (%d, %t), want (%d, true)", test.networkID, got, found, runtimeID)
+			}
+			if got, found := test.codec.FromRuntimeID(runtimeID); !found || got != test.networkID {
+				t.Fatalf("FromRuntimeID(%d) = (%d, %t), want (%d, true)", runtimeID, got, found, test.networkID)
+			}
+			if got := test.codec.Mode(); got != blocknetwork.ModeFromHashes(test.name == "hashes") {
+				t.Fatalf("Mode() = %v, unexpected for %s", got, test.name)
+			}
+		})
+	}
+}
+
+func TestCodecRejectsUnknownIDs(t *testing.T) {
+	t.Parallel()
+
+	runtimeCodec := blocknetwork.NewCodec(world.BlockRegistry, blocknetwork.RuntimeIDs)
+	hashCodec := blocknetwork.NewCodec(world.BlockRegistry, blocknetwork.Hashes)
+	unknownRuntimeID := uint32(world.BlockRegistry.BlockCount() + 100)
+	unknownHash := unknownNetworkHash(t)
+
+	if _, ok := runtimeCodec.ToRuntimeID(unknownRuntimeID); ok {
+		t.Fatalf("runtime codec accepted unknown runtime ID %d", unknownRuntimeID)
+	}
+	if _, ok := runtimeCodec.FromRuntimeID(unknownRuntimeID); ok {
+		t.Fatalf("runtime codec encoded unknown runtime ID %d", unknownRuntimeID)
+	}
+	if _, ok := hashCodec.ToRuntimeID(unknownHash); ok {
+		t.Fatalf("hash codec accepted unknown hash %d", unknownHash)
+	}
+	if _, ok := hashCodec.FromRuntimeID(unknownRuntimeID); ok {
+		t.Fatalf("hash codec encoded unknown runtime ID %d", unknownRuntimeID)
+	}
+}
+
+func TestTranslatorConvertsBetweenModes(t *testing.T) {
+	t.Parallel()
+
+	runtimeID := world.BlockRegistry.BlockRuntimeID(block.Stone{})
+	networkHash, ok := world.BlockRegistry.RuntimeIDToHash(runtimeID)
+	if !ok {
+		t.Fatal("stone runtime ID has no network hash")
+	}
+	runtimeCodec := blocknetwork.NewCodec(world.BlockRegistry, blocknetwork.RuntimeIDs)
+	hashCodec := blocknetwork.NewCodec(world.BlockRegistry, blocknetwork.Hashes)
+
+	tests := []struct {
+		name   string
+		source blocknetwork.Codec
+		target blocknetwork.Codec
+		input  uint32
+		want   uint32
+		needed bool
+	}{
+		{name: "runtime to runtime", source: runtimeCodec, target: runtimeCodec, input: runtimeID, want: runtimeID},
+		{name: "runtime to hash", source: runtimeCodec, target: hashCodec, input: runtimeID, want: networkHash, needed: true},
+		{name: "hash to runtime", source: hashCodec, target: runtimeCodec, input: networkHash, want: runtimeID, needed: true},
+		{name: "hash to hash", source: hashCodec, target: hashCodec, input: networkHash, want: networkHash},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			translator := blocknetwork.NewTranslator(test.source, test.target)
+			if got := translator.Required(); got != test.needed {
+				t.Fatalf("Required() = %t, want %t", got, test.needed)
+			}
+			if got := translator.Translate(test.input); got != test.want {
+				t.Fatalf("Translate(%d) = %d, want %d", test.input, got, test.want)
+			}
+		})
+	}
+}
+
+func TestTranslatorPreservesUnknownAndHighBitIDs(t *testing.T) {
+	t.Parallel()
+
+	runtimeCodec := blocknetwork.NewCodec(world.BlockRegistry, blocknetwork.RuntimeIDs)
+	hashCodec := blocknetwork.NewCodec(world.BlockRegistry, blocknetwork.Hashes)
+	unknownHash := unknownNetworkHash(t)
+	if got := blocknetwork.NewTranslator(hashCodec, runtimeCodec).Translate(unknownHash); got != unknownHash {
+		t.Fatalf("unknown hash translated to %d, want original %d", got, unknownHash)
+	}
+	unknownRuntimeID := uint32(world.BlockRegistry.BlockCount() + 100)
+	if got := blocknetwork.NewTranslator(runtimeCodec, hashCodec).Translate(unknownRuntimeID); got != unknownRuntimeID {
+		t.Fatalf("unknown runtime ID translated to %d, want original %d", got, unknownRuntimeID)
+	}
+
+	highBitHash, runtimeID := highBitNetworkHash(t)
+	if got := blocknetwork.NewTranslator(hashCodec, runtimeCodec).Translate(highBitHash); got != runtimeID {
+		t.Fatalf("high-bit hash %#x translated to %d, want runtime ID %d", highBitHash, got, runtimeID)
+	}
+	if got := blocknetwork.NewTranslator(runtimeCodec, hashCodec).Translate(runtimeID); got != highBitHash {
+		t.Fatalf("runtime ID %d translated to %#x, want high-bit hash %#x", runtimeID, got, highBitHash)
+	}
+}
+
+func TestNewCodecRejectsNilRegistry(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("NewCodec(nil, RuntimeIDs) did not panic")
+		}
+	}()
+	blocknetwork.NewCodec(nil, blocknetwork.RuntimeIDs)
+}
+
+func unknownNetworkHash(t *testing.T) uint32 {
+	t.Helper()
+	for hash := uint32(math.MaxUint32); ; hash-- {
+		if _, ok := world.BlockRegistry.HashToRuntimeID(hash); !ok {
+			return hash
+		}
+	}
+}
+
+func highBitNetworkHash(t *testing.T) (uint32, uint32) {
+	t.Helper()
+	for runtimeID := range uint32(world.BlockRegistry.BlockCount()) {
+		hash, ok := world.BlockRegistry.RuntimeIDToHash(runtimeID)
+		if ok && hash > math.MaxInt32 {
+			return hash, runtimeID
+		}
+	}
+	t.Fatal("block registry contains no high-bit network hash")
+	return 0, 0
+}

--- a/world/blocknetwork/codec_test.go
+++ b/world/blocknetwork/codec_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/df-mc/dragonfly/server/block"
+	"github.com/df-mc/dragonfly/server/world/chunk"
 	"github.com/oomph-ac/oomph/world"
 	"github.com/oomph-ac/oomph/world/blocknetwork"
 )
@@ -77,6 +78,21 @@ func TestCodecRejectsUnknownIDs(t *testing.T) {
 	}
 	if _, ok := hashCodec.FromRuntimeID(unknownRuntimeID); ok {
 		t.Fatalf("hash codec encoded unknown runtime ID %d", unknownRuntimeID)
+	}
+}
+
+func TestRuntimeCodecUsesRegistryLookupInsteadOfAssumingDenseIDs(t *testing.T) {
+	t.Parallel()
+
+	runtimeID := world.BlockRegistry.BlockRuntimeID(block.Stone{})
+	registry := sparseBlockRegistry{BlockRegistry: world.BlockRegistry, missing: runtimeID}
+	codec := blocknetwork.NewCodec(registry, blocknetwork.RuntimeIDs)
+
+	if _, ok := codec.ToRuntimeID(runtimeID); ok {
+		t.Fatalf("runtime codec accepted missing runtime ID %d", runtimeID)
+	}
+	if _, ok := codec.FromRuntimeID(runtimeID); ok {
+		t.Fatalf("runtime codec encoded missing runtime ID %d", runtimeID)
 	}
 }
 
@@ -170,4 +186,16 @@ func highBitNetworkHash(t *testing.T) (uint32, uint32) {
 	}
 	t.Fatal("block registry contains no high-bit network hash")
 	return 0, 0
+}
+
+type sparseBlockRegistry struct {
+	chunk.BlockRegistry
+	missing uint32
+}
+
+func (r sparseBlockRegistry) RuntimeIDToState(runtimeID uint32) (string, map[string]any, bool) {
+	if runtimeID == r.missing {
+		return "", nil, false
+	}
+	return r.BlockRegistry.RuntimeIDToState(runtimeID)
 }

--- a/world/blocknetwork/mode.go
+++ b/world/blocknetwork/mode.go
@@ -1,0 +1,20 @@
+// Package blocknetwork converts block IDs between Bedrock's runtime-ID and network-hash representations.
+package blocknetwork
+
+// Mode identifies the block ID representation used by a network endpoint.
+type Mode uint8
+
+const (
+	// RuntimeIDs identifies ordinary block-registry runtime IDs.
+	RuntimeIDs Mode = iota
+	// Hashes identifies block network hashes.
+	Hashes
+)
+
+// ModeFromHashes returns Hashes when enabled is true and RuntimeIDs otherwise.
+func ModeFromHashes(enabled bool) Mode {
+	if enabled {
+		return Hashes
+	}
+	return RuntimeIDs
+}


### PR DESCRIPTION
## Summary

- add immutable runtime-ID and network-hash codecs backed by Dragonfly block registries
- add endpoint translators that preserve unknown and custom IDs
- cover every source/target mode combination, unknown IDs, and high-bit hashes

This is intentionally separate from the packet translation changes so Oomph and Lunar can share the same mode abstraction. Dragonfly remains responsible for the primitive registry mappings.

## Validation

- `go test ./world/blocknetwork -count=1`
- `go test -race ./world/blocknetwork -count=1`
- `go test ./... -count=1`
- `go vet ./...`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New isolated library with no call-site changes in this PR; behavior is covered by tests and only affects future block-ID translation on the network path.
> 
> **Overview**
> Adds a new **`world/blocknetwork`** package so Oomph/Lunar can share one abstraction for Bedrock block IDs on the wire, separate from packet translation.
> 
> **`Mode`** (`RuntimeIDs` vs **`Hashes`**) and **`ModeFromHashes`** describe how an endpoint encodes blocks. **`Codec`** maps between that wire form and canonical Dragonfly **`chunk.BlockRegistry`** runtime IDs (hash mode uses registry hash APIs; runtime mode validates via **`RuntimeIDToState`** instead of assuming dense IDs). **`Translator`** converts IDs between two codecs when modes differ; **`Required()`** is false for same-mode pairs, and **`Translate`** leaves unknown IDs unchanged.
> 
> Tests cover both modes, all translator combinations, nil registry panic, sparse registry gaps, and high-bit network hashes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cc3a96b22087882483dce05bc704b467afe6abd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for identifying blocks using either runtime IDs or network hashes.
  * Added conversion utilities to translate IDs between the two representations, including safe handling of unknown values.
  * Introduced an explicit mode selector to choose hash-based behavior when enabled.
* **Tests**
  * Added/expanded tests covering mode selection, accurate conversions, unknown/invalid ID rejection, preservation of unknown/high-bit IDs, and nil-registry safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->