### PR TITLE
Add chunk operations to block network codecs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/oomph-ac/oomph
 
 go 1.26.0
 
-replace github.com/df-mc/dragonfly => github.com/oomph-ac/dragonfly v0.0.0-20260702190811-865056f9d47f
+replace github.com/df-mc/dragonfly => github.com/oomph-ac/dragonfly v0.0.0-20260713230435-a683785ee72e
 
 replace github.com/sandertv/gophertunnel => github.com/hashimthearab/gophertunnel v1.25.3-0.20260713165240-828896b9c778
 

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,8 @@ github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.17.0 h1:9Luw4uT5HTjHTN8+aNcSThgH1vdXnmdJ8xIfZ4wyTRE=
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
-github.com/oomph-ac/dragonfly v0.0.0-20260702190811-865056f9d47f h1:F1qyVUh1JMkYI1o6XzOQy1cFFdanPsOepv+jZSzZ3qo=
-github.com/oomph-ac/dragonfly v0.0.0-20260702190811-865056f9d47f/go.mod h1:OFJjCz3xfDalVZEtV4lJdbenwKDEAczKHikHN7kVwMc=
+github.com/oomph-ac/dragonfly v0.0.0-20260713230435-a683785ee72e h1:b0O+I3X11M91SlUlvDEZ7Nihohb0SoUnOiUCZufXyfE=
+github.com/oomph-ac/dragonfly v0.0.0-20260713230435-a683785ee72e/go.mod h1:OFJjCz3xfDalVZEtV4lJdbenwKDEAczKHikHN7kVwMc=
 github.com/pion/datachannel v1.6.0 h1:XecBlj+cvsxhAMZWFfFcPyUaDZtd7IJvrXqlXD/53i0=
 github.com/pion/datachannel v1.6.0/go.mod h1:ur+wzYF8mWdC+Mkis5Thosk+u/VOL287apDNEbFpsIk=
 github.com/pion/dtls/v3 v3.1.2 h1:gqEdOUXLtCGW+afsBLO0LtDD8GnuBBjEy6HRtyofZTc=

--- a/world/blocknetwork/codec.go
+++ b/world/blocknetwork/codec.go
@@ -69,17 +69,6 @@ func (c Codec) EncodeChunk(ch *chunk.Chunk) chunk.SerialisedData {
 	return chunk.Encode(ch, chunk.NetworkEncoding)
 }
 
-// EncodeSubChunk encodes one canonical sub-chunk using the codec's network representation without mutating ch.
-func (c Codec) EncodeSubChunk(ch *chunk.Chunk, index int) []byte {
-	if ch == nil || index < 0 || index >= len(ch.Sub()) {
-		return nil
-	}
-	if c.mode == Hashes {
-		return chunk.EncodeSubChunkWithBlockNetworkHashes(ch, index)
-	}
-	return chunk.EncodeSubChunk(ch, chunk.NetworkEncoding, index)
-}
-
 // Translator converts block IDs from one endpoint codec to another.
 type Translator struct {
 	source Codec

--- a/world/blocknetwork/codec.go
+++ b/world/blocknetwork/codec.go
@@ -13,6 +13,9 @@ func NewCodec(registry chunk.BlockRegistry, mode Mode) Codec {
 	if registry == nil {
 		panic("blocknetwork: nil block registry")
 	}
+	if mode != RuntimeIDs && mode != Hashes {
+		panic("blocknetwork: invalid mode")
+	}
 	return Codec{registry: registry, mode: mode}
 }
 
@@ -37,6 +40,44 @@ func (c Codec) FromRuntimeID(runtimeID uint32) (uint32, bool) {
 	}
 	_, _, ok := c.registry.RuntimeIDToState(runtimeID)
 	return runtimeID, ok
+}
+
+// NormalizeChunk converts block palettes in ch from the codec's network representation to canonical runtime IDs.
+// Unknown IDs are preserved.
+func (c Codec) NormalizeChunk(ch *chunk.Chunk) {
+	if ch != nil && c.mode == Hashes {
+		ch.ConvertBlockNetworkHashesToRuntimeIDs()
+	}
+}
+
+// NormalizeSubChunk converts block palettes in sub from the codec's network representation to canonical runtime IDs.
+// Unknown IDs are preserved.
+func (c Codec) NormalizeSubChunk(sub *chunk.SubChunk) {
+	if sub != nil && c.mode == Hashes {
+		sub.ConvertBlockNetworkHashesToRuntimeIDs(c.registry)
+	}
+}
+
+// EncodeChunk encodes a canonical chunk using the codec's network representation without mutating ch.
+func (c Codec) EncodeChunk(ch *chunk.Chunk) chunk.SerialisedData {
+	if ch == nil {
+		return chunk.SerialisedData{}
+	}
+	if c.mode == Hashes {
+		return chunk.EncodeWithBlockNetworkHashes(ch)
+	}
+	return chunk.Encode(ch, chunk.NetworkEncoding)
+}
+
+// EncodeSubChunk encodes one canonical sub-chunk using the codec's network representation without mutating ch.
+func (c Codec) EncodeSubChunk(ch *chunk.Chunk, index int) []byte {
+	if ch == nil || index < 0 || index >= len(ch.Sub()) {
+		return nil
+	}
+	if c.mode == Hashes {
+		return chunk.EncodeSubChunkWithBlockNetworkHashes(ch, index)
+	}
+	return chunk.EncodeSubChunk(ch, chunk.NetworkEncoding, index)
 }
 
 // Translator converts block IDs from one endpoint codec to another.

--- a/world/blocknetwork/codec_test.go
+++ b/world/blocknetwork/codec_test.go
@@ -1,11 +1,13 @@
 package blocknetwork_test
 
 import (
+	"bytes"
 	"math"
 	"os"
 	"testing"
 
 	"github.com/df-mc/dragonfly/server/block"
+	dfworld "github.com/df-mc/dragonfly/server/world"
 	"github.com/df-mc/dragonfly/server/world/chunk"
 	"github.com/oomph-ac/oomph/world"
 	"github.com/oomph-ac/oomph/world/blocknetwork"
@@ -96,6 +98,108 @@ func TestRuntimeCodecUsesRegistryLookupInsteadOfAssumingDenseIDs(t *testing.T) {
 	}
 }
 
+func TestCodecNormalizesChunkPalettes(t *testing.T) {
+	runtimeID := world.BlockRegistry.BlockRuntimeID(block.Stone{})
+	networkHash, ok := world.BlockRegistry.RuntimeIDToHash(runtimeID)
+	if !ok {
+		t.Fatal("stone runtime ID has no network hash")
+	}
+
+	for _, test := range []struct {
+		name    string
+		mode    blocknetwork.Mode
+		inputID uint32
+	}{
+		{name: "runtime IDs", mode: blocknetwork.RuntimeIDs, inputID: runtimeID},
+		{name: "hashes", mode: blocknetwork.Hashes, inputID: networkHash},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			c := chunk.New(world.BlockRegistry, dfworld.Overworld.Range())
+			c.SetBlock(1, 0, 1, 0, test.inputID)
+			codec := blocknetwork.NewCodec(world.BlockRegistry, test.mode)
+
+			codec.NormalizeChunk(c)
+
+			if got := c.Block(1, 0, 1, 0); got != runtimeID {
+				t.Fatalf("normalized block ID = %d, want runtime ID %d", got, runtimeID)
+			}
+		})
+	}
+}
+
+func TestCodecNormalizesSubChunkPalettesAndPreservesUnknownIDs(t *testing.T) {
+	runtimeID := world.BlockRegistry.BlockRuntimeID(block.Stone{})
+	networkHash, ok := world.BlockRegistry.RuntimeIDToHash(runtimeID)
+	if !ok {
+		t.Fatal("stone runtime ID has no network hash")
+	}
+	unknownHash := unknownPaletteID(t)
+	c := chunk.New(world.BlockRegistry, dfworld.Overworld.Range())
+	c.SetBlock(1, 0, 1, 0, networkHash)
+	c.SetBlock(2, 0, 2, 0, unknownHash)
+	codec := blocknetwork.NewCodec(world.BlockRegistry, blocknetwork.Hashes)
+
+	codec.NormalizeSubChunk(c.Sub()[c.SubIndex(0)])
+
+	if got := c.Block(1, 0, 1, 0); got != runtimeID {
+		t.Fatalf("normalized block ID = %d, want runtime ID %d", got, runtimeID)
+	}
+	if got := c.Block(2, 0, 2, 0); got != unknownHash {
+		t.Fatalf("unknown block ID = %d, want preserved hash %d", got, unknownHash)
+	}
+}
+
+func TestCodecEncodesChunkWithoutMutatingCanonicalSource(t *testing.T) {
+	runtimeID := world.BlockRegistry.BlockRuntimeID(block.Stone{})
+	networkHash, ok := world.BlockRegistry.RuntimeIDToHash(runtimeID)
+	if !ok {
+		t.Fatal("stone runtime ID has no network hash")
+	}
+
+	for _, test := range []struct {
+		name   string
+		mode   blocknetwork.Mode
+		wantID uint32
+	}{
+		{name: "runtime IDs", mode: blocknetwork.RuntimeIDs, wantID: runtimeID},
+		{name: "hashes", mode: blocknetwork.Hashes, wantID: networkHash},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			c := chunk.New(world.BlockRegistry, dfworld.Overworld.Range())
+			c.SetBlock(1, 0, 1, 0, runtimeID)
+			codec := blocknetwork.NewCodec(world.BlockRegistry, test.mode)
+
+			encoded := codec.EncodeChunk(c)
+			decoded := decodeChunk(t, encoded)
+
+			if got := decoded.Block(1, 0, 1, 0); got != test.wantID {
+				t.Fatalf("encoded block ID = %d, want %d", got, test.wantID)
+			}
+			if got := c.Block(1, 0, 1, 0); got != runtimeID {
+				t.Fatalf("source block ID = %d, want unchanged runtime ID %d", got, runtimeID)
+			}
+		})
+	}
+}
+
+func TestCodecEncodesSubChunkForMode(t *testing.T) {
+	c := chunk.New(world.BlockRegistry, dfworld.Overworld.Range())
+	c.SetBlock(1, 0, 1, 0, world.BlockRegistry.BlockRuntimeID(block.Stone{}))
+	for _, mode := range []blocknetwork.Mode{blocknetwork.RuntimeIDs, blocknetwork.Hashes} {
+		codec := blocknetwork.NewCodec(world.BlockRegistry, mode)
+		got := codec.EncodeSubChunk(c, 0)
+		var want []byte
+		if mode == blocknetwork.Hashes {
+			want = chunk.EncodeSubChunkWithBlockNetworkHashes(c, 0)
+		} else {
+			want = chunk.EncodeSubChunk(c, chunk.NetworkEncoding, 0)
+		}
+		if !bytes.Equal(got, want) {
+			t.Fatalf("EncodeSubChunk mode %v did not use expected network representation", mode)
+		}
+	}
+}
+
 func TestTranslatorConvertsBetweenModes(t *testing.T) {
 	t.Parallel()
 
@@ -167,6 +271,17 @@ func TestNewCodecRejectsNilRegistry(t *testing.T) {
 	blocknetwork.NewCodec(nil, blocknetwork.RuntimeIDs)
 }
 
+func TestNewCodecRejectsInvalidMode(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("NewCodec accepted an invalid mode")
+		}
+	}()
+	blocknetwork.NewCodec(world.BlockRegistry, blocknetwork.Mode(255))
+}
+
 func unknownNetworkHash(t *testing.T) uint32 {
 	t.Helper()
 	for hash := uint32(math.MaxUint32); ; hash-- {
@@ -174,6 +289,17 @@ func unknownNetworkHash(t *testing.T) uint32 {
 			return hash
 		}
 	}
+}
+
+func unknownPaletteID(t *testing.T) uint32 {
+	t.Helper()
+	for hash := uint32(1_000_000_000); hash > 0; hash-- {
+		if _, ok := world.BlockRegistry.HashToRuntimeID(hash); !ok {
+			return hash
+		}
+	}
+	t.Fatal("block registry has no unknown palette ID")
+	return 0
 }
 
 func highBitNetworkHash(t *testing.T) (uint32, uint32) {
@@ -186,6 +312,20 @@ func highBitNetworkHash(t *testing.T) (uint32, uint32) {
 	}
 	t.Fatal("block registry contains no high-bit network hash")
 	return 0, 0
+}
+
+func decodeChunk(t *testing.T, data chunk.SerialisedData) *chunk.Chunk {
+	t.Helper()
+	raw := bytes.NewBuffer(nil)
+	for _, sub := range data.SubChunks {
+		raw.Write(sub)
+	}
+	raw.Write(data.Biomes)
+	decoded, err := chunk.NetworkDecode(world.BlockRegistry, raw.Bytes(), len(data.SubChunks), dfworld.Overworld.Range())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return decoded
 }
 
 type sparseBlockRegistry struct {

--- a/world/blocknetwork/codec_test.go
+++ b/world/blocknetwork/codec_test.go
@@ -182,24 +182,6 @@ func TestCodecEncodesChunkWithoutMutatingCanonicalSource(t *testing.T) {
 	}
 }
 
-func TestCodecEncodesSubChunkForMode(t *testing.T) {
-	c := chunk.New(world.BlockRegistry, dfworld.Overworld.Range())
-	c.SetBlock(1, 0, 1, 0, world.BlockRegistry.BlockRuntimeID(block.Stone{}))
-	for _, mode := range []blocknetwork.Mode{blocknetwork.RuntimeIDs, blocknetwork.Hashes} {
-		codec := blocknetwork.NewCodec(world.BlockRegistry, mode)
-		got := codec.EncodeSubChunk(c, 0)
-		var want []byte
-		if mode == blocknetwork.Hashes {
-			want = chunk.EncodeSubChunkWithBlockNetworkHashes(c, 0)
-		} else {
-			want = chunk.EncodeSubChunk(c, chunk.NetworkEncoding, 0)
-		}
-		if !bytes.Equal(got, want) {
-			t.Fatalf("EncodeSubChunk mode %v did not use expected network representation", mode)
-		}
-	}
-}
-
 func TestTranslatorConvertsBetweenModes(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- add codec-owned normalization for full chunks and individual subchunks
- add codec-owned network encoding for full chunks and individual subchunks
- preserve canonical source chunks and unknown palette IDs
- reject invalid block-network modes
- advance the Dragonfly fork pin to the published non-mutating hash chunk helpers

## Why

Consumers currently inspect the codec mode and select Dragonfly hash helpers themselves. These methods make the codec the complete boundary for scalar IDs and chunk palettes, allowing Oomph and Lunar to avoid duplicated hash-mode branching.

## Validation

- go test -race ./... -count=1
- go vet ./...
- git diff --check
- codex review --base origin/stable

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches world/chunk wire encoding paths where palette mistakes can corrupt blocks; scope is localized to blocknetwork with solid tests and a dependency pin.
> 
> **Overview**
> Extends **`blocknetwork.Codec`** so callers no longer branch on hash vs runtime-ID mode when handling chunk palettes. **`NormalizeChunk`** / **`NormalizeSubChunk`** convert hash-mode palettes to canonical runtime IDs (unknown IDs stay put); **`EncodeChunk`** serializes a canonical chunk in the codec’s wire representation **without mutating** the source.
> 
> **`NewCodec`** now panics on invalid modes. The **Dragonfly fork** pin moves to a build that exposes the non-mutating hash encode/normalize helpers this API delegates to.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 207b5641702b975fc6dc1f156e6fc6a31631595b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added codec support to normalize and encode chunks/sub-chunks in both runtime ID and hash-based modes.
  - Normalization converts palette data only in hash mode, and preserves unknown identifiers.
- **Bug Fixes**
  - Chunk encoding no longer mutates the source chunk.
- **Tests**
  - Added tests for palette normalization, encoding/decode round-trips, unknown ID preservation, and rejecting invalid codec modes.
- **Chores**
  - Updated the Dragonfly dependency to a newer version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->