### PR TITLE
dragonfly: wrap existing listeners

### DIFF
--- a/integration/dragonfly/listener.go
+++ b/integration/dragonfly/listener.go
@@ -62,16 +62,39 @@ func Listener(ctx context.Context, cfg Config) func(server.Config) (server.Liste
 			return nil, fmt.Errorf("dragonfly integration: listen: %w", err)
 		}
 		log.Info("Dragonfly with Oomph listening", "addr", raw.Addr())
-		l := &listener{raw: raw, log: log, configure: cfg.Configure, done: make(chan struct{})}
-		go func() {
-			select {
-			case <-ctx.Done():
-				_ = l.Close()
-			case <-l.done:
-			}
-		}()
-		return l, nil
+		return newListener(ctx, nil, raw, log, cfg.Configure), nil
 	}
+}
+
+// Wrap adds Oomph packet processing to a Dragonfly listener factory backed by
+// a gophertunnel RakNet or NetherNet listener.
+func Wrap(ctx context.Context, next func(server.Config) (server.Listener, error), configure func(*player.Player)) func(server.Config) (server.Listener, error) {
+	return func(conf server.Config) (server.Listener, error) {
+		if next == nil {
+			return nil, fmt.Errorf("dragonfly integration: wrapped listener factory is required")
+		}
+		base, err := next(conf)
+		if err != nil {
+			return nil, fmt.Errorf("dragonfly integration: create wrapped listener: %w", err)
+		}
+		log := conf.Log
+		if log == nil {
+			log = slog.Default()
+		}
+		return newListener(ctx, base, nil, log, configure), nil
+	}
+}
+
+func newListener(ctx context.Context, base server.Listener, raw *minecraft.Listener, log *slog.Logger, configure func(*player.Player)) *listener {
+	l := &listener{base: base, raw: raw, log: log, configure: configure, done: make(chan struct{})}
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = l.Close()
+		case <-l.done:
+		}
+	}()
+	return l
 }
 
 func listenerCompression(compression packet.Compression) packet.Compression {
@@ -82,6 +105,7 @@ func listenerCompression(compression packet.Compression) packet.Compression {
 }
 
 type listener struct {
+	base      server.Listener
 	raw       *minecraft.Listener
 	log       *slog.Logger
 	configure func(*player.Player)
@@ -91,14 +115,29 @@ type listener struct {
 }
 
 func (l *listener) Accept() (session.Conn, error) {
-	raw, err := l.raw.Accept()
-	if err != nil {
-		return nil, err
+	var accepted session.Conn
+	if l.base != nil {
+		conn, err := l.base.Accept()
+		if err != nil {
+			return nil, err
+		}
+		accepted = conn
+	} else {
+		raw, err := l.raw.Accept()
+		if err != nil {
+			return nil, err
+		}
+		conn, ok := raw.(*minecraft.Conn)
+		if !ok {
+			_ = raw.Close()
+			return nil, fmt.Errorf("dragonfly integration: unexpected connection type %T", raw)
+		}
+		accepted = conn
 	}
-	conn, ok := raw.(*minecraft.Conn)
+	conn, ok := accepted.(*minecraft.Conn)
 	if !ok {
-		_ = raw.Close()
-		return nil, fmt.Errorf("dragonfly integration: unexpected connection type %T", raw)
+		_ = accepted.Close()
+		return nil, fmt.Errorf("dragonfly integration: unexpected connection type %T", accepted)
 	}
 	p := player.New(l.log.With(
 		"name", conn.IdentityData().DisplayName,
@@ -121,7 +160,9 @@ func (l *listener) Disconnect(conn session.Conn, reason string) error {
 		return fmt.Errorf("dragonfly integration: unexpected session connection type %T", conn)
 	}
 	var disconnectErr error
-	if raw, ok := c.Conn.(*minecraft.Conn); ok && l.raw != nil {
+	if l.base != nil {
+		disconnectErr = l.base.Disconnect(c.Conn, reason)
+	} else if raw, ok := c.Conn.(*minecraft.Conn); ok && l.raw != nil {
 		disconnectErr = l.raw.Disconnect(raw, reason)
 	}
 	return errors.Join(disconnectErr, c.Close())
@@ -130,7 +171,11 @@ func (l *listener) Disconnect(conn session.Conn, reason string) error {
 func (l *listener) Close() error {
 	l.closeOnce.Do(func() {
 		close(l.done)
-		l.closeErr = l.raw.Close()
+		if l.base != nil {
+			l.closeErr = l.base.Close()
+		} else if l.raw != nil {
+			l.closeErr = l.raw.Close()
+		}
 	})
 	return l.closeErr
 }

--- a/integration/dragonfly/listener_test.go
+++ b/integration/dragonfly/listener_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/df-mc/dragonfly/server"
+	"github.com/df-mc/dragonfly/server/session"
 	"github.com/oomph-ac/oomph/player"
 	"github.com/sandertv/gophertunnel/minecraft"
 	"github.com/sandertv/gophertunnel/minecraft/protocol/packet"
@@ -39,6 +41,96 @@ func TestListenerFactoryListensOnEphemeralAddress(t *testing.T) {
 	}
 	if err := l.Close(); err != nil {
 		t.Fatalf("Close() error = %v", err)
+	}
+}
+
+func TestWrapUsesSuppliedListenerFactory(t *testing.T) {
+	base := newStubListener()
+	var gotConfig server.Config
+	factory := Wrap(context.Background(), func(conf server.Config) (server.Listener, error) {
+		gotConfig = conf
+		return base, nil
+	}, nil)
+	wantConfig := server.Config{Log: slog.Default(), Name: "wrapped"}
+
+	l, err := factory(wantConfig)
+	if err != nil {
+		t.Fatalf("Wrap() factory error = %v", err)
+	}
+	if gotConfig.Name != wantConfig.Name {
+		t.Fatalf("factory config name = %q, want %q", gotConfig.Name, wantConfig.Name)
+	}
+	if err := l.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	select {
+	case <-base.closed:
+	default:
+		t.Fatal("Close did not delegate to the supplied listener")
+	}
+}
+
+func TestWrappedListenerDisconnectDelegatesAndClosesOomphPlayer(t *testing.T) {
+	base := newStubListener()
+	l, err := Wrap(context.Background(), func(server.Config) (server.Listener, error) {
+		return base, nil
+	}, nil)(server.Config{Log: slog.Default()})
+	if err != nil {
+		t.Fatalf("Wrap() factory error = %v", err)
+	}
+	raw := newBlockingConn()
+	p := player.New(slog.Default(), player.MonitoringState{CurrentTime: time.Now()}, nil)
+	c := newSessionConn(raw, p)
+
+	if err := l.Disconnect(c, "rejected"); err != nil {
+		t.Fatalf("Disconnect() error = %v", err)
+	}
+	if base.disconnected != raw || base.reason != "rejected" {
+		t.Fatalf("delegated Disconnect() = (%T, %q), want (%T, %q)", base.disconnected, base.reason, raw, "rejected")
+	}
+	select {
+	case <-p.CloseChan:
+	case <-time.After(time.Second):
+		t.Fatal("Disconnect did not close the Oomph player")
+	}
+}
+
+func TestWrappedListenerRejectsAndClosesUnexpectedConnectionType(t *testing.T) {
+	raw := newBlockingConn()
+	base := newStubListener()
+	base.accept = raw
+	l, err := Wrap(context.Background(), func(server.Config) (server.Listener, error) {
+		return base, nil
+	}, nil)(server.Config{Log: slog.Default()})
+	if err != nil {
+		t.Fatalf("Wrap() factory error = %v", err)
+	}
+
+	if _, err := l.Accept(); err == nil {
+		t.Fatal("Accept() accepted a non-minecraft connection")
+	}
+	select {
+	case <-raw.closed:
+	default:
+		t.Fatal("Accept did not close the rejected connection")
+	}
+}
+
+func TestWrappedListenerClosesWhenContextIsCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	base := newStubListener()
+	_, err := Wrap(ctx, func(server.Config) (server.Listener, error) {
+		return base, nil
+	}, nil)(server.Config{Log: slog.Default()})
+	if err != nil {
+		t.Fatalf("Wrap() factory error = %v", err)
+	}
+
+	cancel()
+	select {
+	case <-base.closed:
+	case <-time.After(time.Second):
+		t.Fatal("context cancellation did not close the supplied listener")
 	}
 }
 
@@ -86,4 +178,31 @@ func TestListenerClosesWhenContextIsCancelled(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("context cancellation did not close the listener")
 	}
+}
+
+type stubListener struct {
+	accept       session.Conn
+	acceptErr    error
+	disconnected session.Conn
+	reason       string
+	closed       chan struct{}
+	closeOnce    sync.Once
+}
+
+func newStubListener() *stubListener {
+	return &stubListener{closed: make(chan struct{})}
+}
+
+func (l *stubListener) Accept() (session.Conn, error) {
+	return l.accept, l.acceptErr
+}
+
+func (l *stubListener) Disconnect(conn session.Conn, reason string) error {
+	l.disconnected, l.reason = conn, reason
+	return nil
+}
+
+func (l *stubListener) Close() error {
+	l.closeOnce.Do(func() { close(l.closed) })
+	return nil
 }

--- a/player/player.go
+++ b/player/player.go
@@ -455,6 +455,11 @@ func (p *Player) Disconnect(reason string) {
 }
 
 func (p *Player) BlockAddress(duration time.Duration) {
+	// Native integrations may wrap a listener owned by Dragonfly, in which case
+	// Oomph cannot access transport-specific listener state.
+	if p.listener == nil {
+		return
+	}
 	if rkListener, ok := utils.RaknetListener(p.listener); ok {
 		utils.BlockAddress(rkListener, p.RemoteAddr().(*net.UDPAddr).IP, duration)
 	}

--- a/player/player_test.go
+++ b/player/player_test.go
@@ -1,0 +1,12 @@
+package player
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+)
+
+func TestBlockAddressWithoutRakNetListener(t *testing.T) {
+	p := New(slog.Default(), MonitoringState{CurrentTime: time.Now()}, nil)
+	p.BlockAddress(time.Second)
+}


### PR DESCRIPTION
## Summary

- add a Dragonfly listener decorator for externally created gophertunnel RakNet and NetherNet listeners
- preserve Oomph packet processing while Dragonfly owns the listener and socket lifecycle
- delegate accept, disconnect, close, and context cancellation to the wrapped listener
- safely skip transport-specific address blocking when the underlying RakNet listener is not exposed
- keep the existing Oomph-owned RakNet listener API unchanged

This lets Practice compose Dragonfly’s NetherNet listener with Oomph without opening a second socket. Transport-specific operations such as RakNet address blocking remain available through the existing `Listener` integration.

## Verification

- `go test ./...`
- `go test -race ./integration/dragonfly ./player`
- `go vet ./...`
- `make lint`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `Wrap` capability to integrate Dragonfly listeners with Oomph handling while delegating connection lifecycle to an underlying listener.

* **Bug Fixes**
  * Improved listener wrapping behavior to reuse existing connections and avoid unnecessary sockets.
  * Ensured `Accept`, `Disconnect`, `Close`, and context cancellation properly clean up and close associated resources.
  * Safely handles block-address requests when no network listener is available.
  * Rejects unexpected/unsupported connection types and closes related resources.

* **Tests**
  * Added coverage for wrapper delegation and block-address behavior without a listener.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->