### PR TITLE
Keep authentication enabled in standalone proxy example

### DIFF
--- a/deps/proxy/README.md
+++ b/deps/proxy/README.md
@@ -6,9 +6,6 @@
 p, err := proxy.Listen(ctx, proxy.Config{
 	LocalAddress:  ":19132",
 	RemoteAddress: "127.0.0.1:19133",
-	Listen: minecraft.ListenConfig{
-		AuthenticationDisabled: true,
-	},
 })
 if err != nil {
 	return err
@@ -16,5 +13,7 @@ if err != nil {
 defer p.Close()
 return p.Serve(ctx)
 ```
+
+Client authentication is enabled by default and should remain enabled on a public proxy listener. Disable authentication only on private backend servers that accept connections exclusively from the proxy.
 
 Leave `NewHandler` unset for a proxy-only deployment. Set it to attach packet processing or backend lifecycle handling. Oomph exposes its ready-to-use integration through `github.com/oomph-ac/oomph/integration/proxy`.


### PR DESCRIPTION
## Summary

- remove AuthenticationDisabled from the public standalone proxy example
- clarify that client authentication stays enabled on the public listener
- reserve disabled authentication for private backends restricted to the proxy

## Verification

- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated proxy configuration guidance to clarify that client authentication is enabled by default for public listeners.
  - Added guidance to disable authentication only for private backend servers accessed exclusively through the proxy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->