### PR TITLE
fix: track pose-aware player network offsets

### DIFF
--- a/anticheat/entity/network_offset.go
+++ b/anticheat/entity/network_offset.go
@@ -12,6 +12,15 @@ func networkOffset(entityType string, metadata map[uint32]any) float32 {
 		if utils.HasMetadataFlag[byte](metadata, DataKeyPlayerFlags, DataPlayerFlagSleep) || utils.HasMetadataFlag[int64](metadata, DataKeyFlagsTwo, DataFlagSleeping) {
 			return game.SleepingPlayerHeightOffset
 		}
+		if utils.HasMetadataFlag[int64](metadata, DataKeyFlags, DataFlagSwimming) ||
+			utils.HasMetadataFlag[int64](metadata, DataKeyFlags, DataFlagGliding) ||
+			utils.HasMetadataFlag[int64](metadata, DataKeyFlags, DataFlagSpinAttack) ||
+			utils.HasMetadataFlag[int64](metadata, DataKeyFlagsTwo, DataFlagCrawling) {
+			return game.PronePlayerNetworkOffset
+		}
+		if utils.HasMetadataFlag[int64](metadata, DataKeyFlags, DataFlagSneaking) {
+			return game.SneakingPlayerNetworkOffset
+		}
 		return game.DefaultPlayerHeightOffset
 	case TypeItem, TypeFallingBlock, TypeMinecart, TypeChestMinecart, TypeCommandBlockMinecart, TypeHopperMinecart, TypeTNTMinecart:
 		return game.ItemAndMinecartNetworkOffset

--- a/anticheat/entity/network_offset_test.go
+++ b/anticheat/entity/network_offset_test.go
@@ -1,0 +1,27 @@
+package entity
+
+import "testing"
+
+func TestNetworkOffsetPlayerPoses(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata map[uint32]any
+		want     float32
+	}{
+		{name: "standing", want: 1.62001},
+		{name: "sleeping", metadata: map[uint32]any{DataKeyPlayerFlags: byte(1 << DataPlayerFlagSleep)}, want: 0.2},
+		{name: "sneaking", metadata: map[uint32]any{DataKeyFlags: int64(1 << DataFlagSneaking)}, want: 1.27001},
+		{name: "swimming", metadata: map[uint32]any{DataKeyFlags: int64(1 << DataFlagSwimming)}, want: 0.4},
+		{name: "gliding", metadata: map[uint32]any{DataKeyFlags: int64(1 << DataFlagGliding)}, want: 0.4},
+		{name: "spin attack", metadata: map[uint32]any{DataKeyFlags: int64(1 << DataFlagSpinAttack)}, want: 0.4},
+		{name: "crawling", metadata: map[uint32]any{DataKeyFlagsTwo: int64(1 << (DataFlagCrawling % 64))}, want: 0.4},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := networkOffset(TypePlayer, tt.metadata); got != tt.want {
+				t.Fatalf("network offset = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/anticheat/entity/network_offset_test.go
+++ b/anticheat/entity/network_offset_test.go
@@ -1,6 +1,10 @@
 package entity
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/go-gl/mathgl/mgl32"
+)
 
 func TestNetworkOffsetPlayerPoses(t *testing.T) {
 	tests := []struct {
@@ -23,5 +27,27 @@ func TestNetworkOffsetPlayerPoses(t *testing.T) {
 				t.Fatalf("network offset = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestEntityUpdateMetadataRefreshesNetworkOffset(t *testing.T) {
+	e := New(Config{
+		Type:            TypePlayer,
+		Metadata:        map[uint32]any{},
+		NetworkPosition: mgl32.Vec3{0, 100, 0},
+		HistorySize:     4,
+		IsPlayer:        true,
+	})
+
+	if e.NetworkOffset != 1.62001 {
+		t.Fatalf("initial network offset = %v, want %v", e.NetworkOffset, float32(1.62001))
+	}
+	e.UpdateMetadata(map[uint32]any{DataKeyFlags: int64(1 << DataFlagSneaking)})
+	if e.NetworkOffset != 1.27001 {
+		t.Fatalf("sneaking network offset = %v, want %v", e.NetworkOffset, float32(1.27001))
+	}
+	e.UpdateMetadata(map[uint32]any{DataKeyFlags: int64(1 << DataFlagSwimming)})
+	if e.NetworkOffset != 0.4 {
+		t.Fatalf("swimming network offset = %v, want %v", e.NetworkOffset, float32(0.4))
 	}
 }

--- a/anticheat/game/movement.go
+++ b/anticheat/game/movement.go
@@ -18,9 +18,11 @@ const (
 	MaxSneakImpulse      = float32(0.3)
 	MaxNormalizedImpulse = float32(0.70710678118) // 1/sqrt(2)
 
-	DefaultPlayerHeightOffset  = float32(1.62001)
-	SneakingPlayerHeightOffset = float32(1.27)
-	SleepingPlayerHeightOffset = float32(0.2)
+	DefaultPlayerHeightOffset   = float32(1.62001)
+	SneakingPlayerHeightOffset  = float32(1.27)
+	SneakingPlayerNetworkOffset = float32(1.27001)
+	PronePlayerNetworkOffset    = float32(0.4)
+	SleepingPlayerHeightOffset  = float32(0.2)
 
 	ItemAndMinecartNetworkOffset = float32(0.5)
 	BoatNetworkOffset            = float32(0.375)


### PR DESCRIPTION
## Summary

- Track sneaking, swimming, crawling, gliding, and spin-attack player network offsets.
- Recompute the stored offset when entity metadata changes.
- Add regression coverage for each supported player pose.

## Verification

- `go test ./entity ./game`

This follows the merged entity network-offset normalization work in #150.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved movement detection for players who are sneaking, swimming, gliding, crawling, sleeping, or performing spin attacks.
  * Adjusted player height calculations to better reflect prone and sneaking poses.

* **Tests**
  * Added coverage for network offsets across supported player poses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->